### PR TITLE
ログアウトボタンの表示条件を認証状態に基づくように変更 #26

### DIFF
--- a/app/src/components/Header.vue
+++ b/app/src/components/Header.vue
@@ -5,6 +5,9 @@
     <v-btn v-if="auth.isAuthenticated" @click="logout" color="white">
       ログアウト
     </v-btn>
+    <v-btn v-else @click="goToLogin" color="white" variant="outlined">
+      ログイン
+    </v-btn>
   </v-app-bar>
 </template>
 
@@ -18,5 +21,9 @@ const auth = useAuthStore()
 const logout = () => {
   auth.clearToken()
   router.push('/')
+}
+
+const goToLogin = () => {
+  router.push('/login')
 }
 </script>

--- a/app/src/components/Header.vue
+++ b/app/src/components/Header.vue
@@ -2,22 +2,21 @@
   <v-app-bar app color="primary" dark>
     <v-img src="/kdtech-icon.png" alt="Logo" max-width="200" class="mr-4" />
     <v-spacer></v-spacer>
-    <v-btn v-if="showLogout" @click="logout" color="white"> ログアウト </v-btn>
+    <v-btn v-if="auth.isAuthenticated" @click="logout" color="white">
+      ログアウト
+    </v-btn>
   </v-app-bar>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 
-const emit = defineEmits<{
-  (e: 'onLogout'): void
-}>()
-
-const route = useRoute()
-const showLogout = computed(() => route.path !== '/login')
+const router = useRouter()
+const auth = useAuthStore()
 
 const logout = () => {
-  emit('onLogout')
+  auth.clearToken()
+  router.push('/')
 }
 </script>


### PR DESCRIPTION
## やったこと
- ログアウト時にlocalstorageを破棄する
- 

## 動作確認
- ログアウト状態　localstorageにauth_tokenが見えない
- <img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/935f0d31-6bf4-497c-abe1-a4701f624f7e" />
- ログイン状態　localstorageにauth_tokenが存在
- <img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/ff9faf2b-9af7-4dfb-8f9c-cdf98b4e25eb" />



Closes #26