### PR TITLE
500ステータスや404ステータス

### DIFF
--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios, { AxiosHeaders } from 'axios'
 import { Api } from './generated/apiSchema'
 
 const baseURL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
@@ -18,6 +18,7 @@ export const setApiErrorHandler = (handler: ApiErrorHandler) => {
 api.instance.interceptors.request.use((config) => {
   const token = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
   if (token) {
+    config.headers = AxiosHeaders.from(config.headers)
     config.headers.set('Authorization', `Bearer ${token}`)
   }
   return config

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import { Api } from './generated/apiSchema'
 
 const baseURL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
@@ -6,6 +7,14 @@ export const AUTH_TOKEN_STORAGE_KEY = 'auth_token'
 
 export const api = new Api({ baseURL })
 
+type ApiErrorHandler = (status: number | null) => void
+
+let apiErrorHandler: ApiErrorHandler | null = null
+
+export const setApiErrorHandler = (handler: ApiErrorHandler) => {
+  apiErrorHandler = handler
+}
+
 api.instance.interceptors.request.use((config) => {
   const token = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
   if (token) {
@@ -13,3 +22,22 @@ api.instance.interceptors.request.use((config) => {
   }
   return config
 })
+
+api.instance.interceptors.response.use(
+  (response) => response,
+  (error: unknown) => {
+    if (axios.isAxiosError(error) && error.code !== 'ERR_CANCELED') {
+      const status = error.response?.status ?? null
+
+      if (status === 404 || (status !== null && status >= 500)) {
+        apiErrorHandler?.(status)
+      }
+
+      if (status === null && error.request) {
+        apiErrorHandler?.(status)
+      }
+    }
+
+    return Promise.reject(error)
+  },
+)

--- a/app/src/features/errors/ErrorStatusView.vue
+++ b/app/src/features/errors/ErrorStatusView.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+
+defineProps<{
+  statusCode: number
+  title: string
+  message: string
+}>()
+
+const router = useRouter()
+</script>
+
+<template>
+  <v-container class="error-status py-12" fluid>
+    <div class="error-status__content">
+      <p class="error-status__code">{{ statusCode }}</p>
+      <h1 class="error-status__title">{{ title }}</h1>
+      <p class="error-status__message">{{ message }}</p>
+
+      <div class="error-status__actions">
+        <v-btn
+          color="primary"
+          size="large"
+          prepend-icon="mdi-home"
+          @click="router.push('/')"
+        >
+          ホームへ戻る
+        </v-btn>
+        <v-btn
+          variant="outlined"
+          size="large"
+          prepend-icon="mdi-refresh"
+          @click="router.go(0)"
+        >
+          再読み込み
+        </v-btn>
+      </div>
+    </div>
+  </v-container>
+</template>
+
+<style scoped>
+.error-status {
+  min-height: calc(100vh - 64px);
+  display: grid;
+  place-items: center;
+}
+
+.error-status__content {
+  width: min(100%, 560px);
+  text-align: center;
+  padding: 32px 20px;
+}
+
+.error-status__code {
+  margin: 0 0 12px;
+  color: rgb(var(--v-theme-primary));
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.error-status__title {
+  margin: 0;
+  font-size: 2rem;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+.error-status__message {
+  margin: 16px auto 0;
+  max-width: 36rem;
+  color: rgba(var(--v-theme-on-surface), 0.72);
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
+.error-status__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 32px;
+}
+
+@media (min-width: 600px) {
+  .error-status__title {
+    font-size: 2.5rem;
+  }
+}
+
+@media (min-width: 960px) {
+  .error-status__title {
+    font-size: 3rem;
+  }
+}
+</style>

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '@/features/home/HomeView.vue'
+import { setApiErrorHandler } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
 
 const router = createRouter({
@@ -29,7 +30,50 @@ const router = createRouter({
       component: () => import('@/features/articles/NewArticleView.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/not-found',
+      name: 'not-found',
+      component: () => import('@/features/errors/ErrorStatusView.vue'),
+      props: {
+        statusCode: 404,
+        title: '何も見つかりません',
+        message:
+          'お探しのページまたはデータが見つかりませんでした。URLを確認するか、ホームへ戻ってください。',
+      },
+    },
+    {
+      path: '/server-error',
+      name: 'server-error',
+      component: () => import('@/features/errors/ErrorStatusView.vue'),
+      props: {
+        statusCode: 500,
+        title: 'サーバーが落ちています',
+        message:
+          'サーバー側で問題が発生しています。時間をおいてから、もう一度お試しください。',
+      },
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      name: 'route-not-found',
+      component: () => import('@/features/errors/ErrorStatusView.vue'),
+      props: {
+        statusCode: 404,
+        title: '何も見つかりません',
+        message:
+          'お探しのページが見つかりませんでした。URLを確認するか、ホームへ戻ってください。',
+      },
+    },
   ],
+})
+
+setApiErrorHandler((status) => {
+  const name = status === 404 ? 'not-found' : 'server-error'
+
+  if (router.currentRoute.value.name === name) {
+    return
+  }
+
+  void router.push({ name }).catch(() => undefined)
 })
 
 router.beforeEach((to) => {


### PR DESCRIPTION
## やったこと
- axios interceptor で 404 / 5xx / 接続失敗時にエラーページへ遷移
- 404 / 500 用のユーザー向けページと catch-all ルートを追加

## 動作確認
- npm run lint:eslint
- npm run type-check
- npm run build

Closes #67