### PR TITLE
記事詳細APIの作成

### DIFF
--- a/api/internal/get_article/handler.go
+++ b/api/internal/get_article/handler.go
@@ -13,7 +13,7 @@ import (
 
 type ErrorResponse struct {
 	Message string `json:"message"`
-} // @name server.getArticleErrorResponse
+} // @name server.articleErrorResponse
 
 type AuthorJSON struct {
 	ID   int64  `json:"id"`

--- a/api/internal/get_article/handler.go
+++ b/api/internal/get_article/handler.go
@@ -1,0 +1,103 @@
+package article
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type ErrorResponse struct {
+	Message string `json:"message"`
+} // @name server.getArticleErrorResponse
+
+type AuthorJSON struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+} // @name server.articleAuthorJSONResponse
+
+type ArticleJSON struct {
+	ID        int64      `json:"id"`
+	Title     string     `json:"title"`
+	Content   string     `json:"content"`
+	Author    AuthorJSON `json:"author"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+} // @name server.getArticleJSONResponse
+
+type Handler struct {
+	repo *Repository
+}
+
+func NewHandler(repo *Repository) *Handler {
+	return &Handler{repo: repo}
+}
+
+func (h *Handler) RegisterRoutes(router gin.IRouter) {
+	router.GET("/articles/:article_id", h.getArticleHandler)
+}
+
+// getArticleHandler godoc
+//
+//	@Summary		Get article
+//	@Description	Get article detail API.
+//	@Tags			articles
+//	@Produce		json
+//	@Param			article_id	path		int	true	"Article ID"
+//	@Success		200			{object}	ArticleJSON
+//	@Failure		400			{object}	ErrorResponse
+//	@Failure		404			{object}	ErrorResponse
+//	@Failure		500			{object}	ErrorResponse
+//	@Router			/api/articles/{article_id} [get]
+func (h *Handler) getArticleHandler(c *gin.Context) {
+	articleID, err := strconv.ParseInt(c.Param("article_id"), 10, 64)
+	if err != nil || articleID <= 0 {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Message: "invalid article_id"})
+		return
+	}
+
+	response, err := h.GetArticle(c.Request.Context(), articleID)
+	if err != nil {
+		switch {
+		case errors.Is(err, errArticleNotFound):
+			c.JSON(http.StatusNotFound, ErrorResponse{Message: err.Error()})
+		default:
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Message: "failed to get article"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+var errArticleNotFound = errors.New("article not found")
+
+func (h *Handler) GetArticle(ctx context.Context, articleID int64) (ArticleJSON, error) {
+	if h == nil || h.repo == nil {
+		return ArticleJSON{}, errors.New("get article handler is not configured")
+	}
+
+	article, err := h.repo.FindByID(ctx, articleID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ArticleJSON{}, errArticleNotFound
+		}
+		return ArticleJSON{}, err
+	}
+
+	return ArticleJSON{
+		ID:      article.ID,
+		Title:   article.Title,
+		Content: article.Content,
+		Author: AuthorJSON{
+			ID:   article.Author.ID,
+			Name: article.Author.Name,
+		},
+		CreatedAt: article.CreatedAt,
+		UpdatedAt: article.UpdatedAt,
+	}, nil
+}

--- a/api/internal/get_article/model.go
+++ b/api/internal/get_article/model.go
@@ -1,0 +1,17 @@
+package article
+
+import "time"
+
+type Author struct {
+	ID   int64
+	Name string
+}
+
+type Article struct {
+	ID        int64
+	Title     string
+	Content   string
+	Author    Author
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/api/internal/get_article/repository.go
+++ b/api/internal/get_article/repository.go
@@ -1,0 +1,51 @@
+package article
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+type Repository struct {
+	db *sql.DB
+}
+
+func NewRepository(db *sql.DB) *Repository {
+	return &Repository{db: db}
+}
+
+func (r *Repository) FindByID(ctx context.Context, id int64) (Article, error) {
+	if r == nil || r.db == nil {
+		return Article{}, errors.New("get article repository is not configured")
+	}
+
+	const query = `
+		SELECT
+			a.id,
+			a.title,
+			a.content,
+			u.id,
+			u.name,
+			a.created_at,
+			a.updated_at
+		FROM articles a
+		JOIN users u ON u.id = a.user_id
+		WHERE a.id = $1
+	`
+
+	var article Article
+	err := r.db.QueryRowContext(ctx, query, id).Scan(
+		&article.ID,
+		&article.Title,
+		&article.Content,
+		&article.Author.ID,
+		&article.Author.Name,
+		&article.CreatedAt,
+		&article.UpdatedAt,
+	)
+	if err != nil {
+		return Article{}, err
+	}
+
+	return article, nil
+}

--- a/api/internal/get_article/repository.go
+++ b/api/internal/get_article/repository.go
@@ -16,7 +16,7 @@ func NewRepository(db *sql.DB) *Repository {
 
 func (r *Repository) FindByID(ctx context.Context, id int64) (Article, error) {
 	if r == nil || r.db == nil {
-		return Article{}, errors.New("get article repository is not configured")
+		return Article{}, errors.New("article repository is not configured")
 	}
 
 	const query = `

--- a/api/internal/server/router.go
+++ b/api/internal/server/router.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/Baymax6s/KOBE-Tech/api/internal/auth"
+	getarticle "github.com/Baymax6s/KOBE-Tech/api/internal/get_article"
 	me "github.com/Baymax6s/KOBE-Tech/api/internal/get_auth_me"
 	listarticle "github.com/Baymax6s/KOBE-Tech/api/internal/get_list_article"
 	postarticle "github.com/Baymax6s/KOBE-Tech/api/internal/post_article"
@@ -14,6 +15,7 @@ import (
 
 func NewHandler(db *sql.DB, validator *auth.Validator, issuer *auth.Issuer) http.Handler {
 	listArticleHandler := listarticle.NewHandler(listarticle.NewRepository(db))
+	getArticleHandler := getarticle.NewHandler(getarticle.NewRepository(db))
 	postArticleHandler := postarticle.NewHandler(postarticle.NewRepository(db))
 	loginHandler := login.NewHandler(login.NewRepository(db), issuer)
 	meHandler := me.NewHandler(me.NewRepository(db))
@@ -28,6 +30,7 @@ func NewHandler(db *sql.DB, validator *auth.Validator, issuer *auth.Issuer) http
 
 	api := router.Group("/api")
 	listArticleHandler.RegisterRoutes(api)
+	getArticleHandler.RegisterRoutes(api)
 	loginHandler.RegisterRoutes(api)
 
 	authRequired := api.Group("", auth.RequireUser(validator))

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -34,11 +34,6 @@ definitions:
       title:
         type: string
     type: object
-  server.getArticleErrorResponse:
-    properties:
-      message:
-        type: string
-    type: object
   server.getArticleJSONResponse:
     properties:
       author:
@@ -172,15 +167,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/server.getArticleErrorResponse'
+            $ref: '#/definitions/server.articleErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/server.getArticleErrorResponse'
+            $ref: '#/definitions/server.articleErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/server.getArticleErrorResponse'
+            $ref: '#/definitions/server.articleErrorResponse'
       summary: Get article
       tags:
       - articles

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -1,5 +1,12 @@
 basePath: /
 definitions:
+  server.articleAuthorJSONResponse:
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+    type: object
   server.articleErrorResponse:
     properties:
       message:
@@ -25,6 +32,26 @@ definitions:
       content:
         type: string
       title:
+        type: string
+    type: object
+  server.getArticleErrorResponse:
+    properties:
+      message:
+        type: string
+    type: object
+  server.getArticleJSONResponse:
+    properties:
+      author:
+        $ref: '#/definitions/server.articleAuthorJSONResponse'
+      content:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: integer
+      title:
+        type: string
+      updated_at:
         type: string
     type: object
   server.listArticlesResponse:
@@ -124,6 +151,37 @@ paths:
       security:
       - BearerAuth: []
       summary: Create article
+      tags:
+      - articles
+  /api/articles/{article_id}:
+    get:
+      description: Get article detail API.
+      parameters:
+      - description: Article ID
+        in: path
+        name: article_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.getArticleJSONResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/server.getArticleErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/server.getArticleErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/server.getArticleErrorResponse'
+      summary: Get article
       tags:
       - articles
   /api/auth/login:

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -93,6 +93,53 @@
                 }
             }
         },
+        "/api/articles/{article_id}": {
+            "get": {
+                "description": "Get article detail API.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "Get article",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Article ID",
+                        "name": "article_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.getArticleJSONResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/server.getArticleErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/server.getArticleErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/server.getArticleErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/auth/login": {
             "post": {
                 "description": "Authenticates a user by name and password, and returns a JWT.",
@@ -184,6 +231,17 @@
         }
     },
     "definitions": {
+        "server.articleAuthorJSONResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "server.articleErrorResponse": {
             "type": "object",
             "properties": {
@@ -222,6 +280,37 @@
                     "type": "string"
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.getArticleErrorResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.getArticleJSONResponse": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "$ref": "#/definitions/server.articleAuthorJSONResponse"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -122,19 +122,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/server.getArticleErrorResponse"
+                            "$ref": "#/definitions/server.articleErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/server.getArticleErrorResponse"
+                            "$ref": "#/definitions/server.articleErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/server.getArticleErrorResponse"
+                            "$ref": "#/definitions/server.articleErrorResponse"
                         }
                     }
                 }
@@ -280,14 +280,6 @@
                     "type": "string"
                 },
                 "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "server.getArticleErrorResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
                     "type": "string"
                 }
             }

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -10,6 +10,11 @@
  * ---------------------------------------------------------------
  */
 
+export interface ServerArticleAuthorJSONResponse {
+  id?: number;
+  name?: string;
+}
+
 export interface ServerArticleErrorResponse {
   message?: string;
 }
@@ -26,6 +31,19 @@ export interface ServerArticleJSONResponse {
 export interface ServerCreateArticleRequest {
   content?: string;
   title?: string;
+}
+
+export interface ServerGetArticleErrorResponse {
+  message?: string;
+}
+
+export interface ServerGetArticleJSONResponse {
+  author?: ServerArticleAuthorJSONResponse;
+  content?: string;
+  created_at?: string;
+  id?: number;
+  title?: string;
+  updated_at?: string;
 }
 
 export interface ServerListArticlesResponse {
@@ -266,6 +284,7 @@ export class Api<
      * @name ArticlesCreate
      * @summary Create article
      * @request POST:/api/articles
+     * @secure
      */
     articlesCreate: (
       request: ServerCreateArticleRequest,
@@ -275,10 +294,29 @@ export class Api<
         path: `/api/articles`,
         method: "POST",
         body: request,
+        secure: true,
         type: ContentType.Json,
         format: "json",
         ...params,
       }),
+
+    /**
+     * @description Get article detail API.
+     *
+     * @tags articles
+     * @name ArticlesDetail
+     * @summary Get article
+     * @request GET:/api/articles/{article_id}
+     */
+    articlesDetail: (articleId: number, params: RequestParams = {}) =>
+      this.request<ServerGetArticleJSONResponse, ServerGetArticleErrorResponse>(
+        {
+          path: `/api/articles/${articleId}`,
+          method: "GET",
+          format: "json",
+          ...params,
+        },
+      ),
 
     /**
      * @description Authenticates a user by name and password, and returns a JWT.
@@ -308,11 +346,13 @@ export class Api<
      * @name AuthMeList
      * @summary Get current user
      * @request GET:/api/auth/me
+     * @secure
      */
     authMeList: (params: RequestParams = {}) =>
       this.request<ServerMeResponse, ServerMeErrorResponse>({
         path: `/api/auth/me`,
         method: "GET",
+        secure: true,
         format: "json",
         ...params,
       }),

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -33,10 +33,6 @@ export interface ServerCreateArticleRequest {
   title?: string;
 }
 
-export interface ServerGetArticleErrorResponse {
-  message?: string;
-}
-
 export interface ServerGetArticleJSONResponse {
   author?: ServerArticleAuthorJSONResponse;
   content?: string;
@@ -309,14 +305,12 @@ export class Api<
      * @request GET:/api/articles/{article_id}
      */
     articlesDetail: (articleId: number, params: RequestParams = {}) =>
-      this.request<ServerGetArticleJSONResponse, ServerGetArticleErrorResponse>(
-        {
-          path: `/api/articles/${articleId}`,
-          method: "GET",
-          format: "json",
-          ...params,
-        },
-      ),
+      this.request<ServerGetArticleJSONResponse, ServerArticleErrorResponse>({
+        path: `/api/articles/${articleId}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
 
     /**
      * @description Authenticates a user by name and password, and returns a JWT.


### PR DESCRIPTION
## やったこと
 - Copilot指摘1を修正: get_articleのエラーレスポンス定義を既存
    のserver.articleErrorResponseに統一
  - Copilot指摘3を修正: repositoryのエラーメッセージをarticle
    repository is not configuredに統一
  - Swagger/OpenAPIを再生成
  - フロントの生成APIクライアントを再生成
  - go test ./...とnpm run type-checkは成功


## 動作確認
済み

Closes #106