### PR TITLE
記事詳細画面を作成 #105

### DIFF
--- a/app/src/features/articles/ArticleCard.vue
+++ b/app/src/features/articles/ArticleCard.vue
@@ -11,7 +11,7 @@ const formattedDate = useDateFormat(
 </script>
 
 <template>
-  <v-card class="p-4">
+  <v-card :to="`/articles/${article.id}`" class="p-4">
     <v-card-title class="text-base font-medium">
       {{ article.title }}
     </v-card-title>

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useDateFormat } from '@vueuse/core'
+import { api } from '@/api/client'
+import type { ServerGetArticleJSONResponse } from '@/api/generated/apiSchema'
+
+defineOptions({
+  name: 'ArticleDetailView',
+})
+
+const props = defineProps<{ articleId: number }>()
+
+const article = ref<ServerGetArticleJSONResponse | null>(null)
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const formattedDate = useDateFormat(
+  () => article.value?.created_at,
+  'YYYY/MM/DD',
+)
+
+onMounted(async () => {
+  loading.value = true
+  try {
+    const response = await api.api.articlesDetail(props.articleId)
+    article.value = response.data
+  } catch {
+    error.value = '記事の取得に失敗しました'
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <v-container class="py-8">
+    <v-row justify="center">
+      <v-col cols="12" md="8" lg="6">
+        <div v-if="loading" class="d-flex justify-center py-12">
+          <v-progress-circular indeterminate color="primary" />
+        </div>
+
+        <v-alert v-else-if="error" type="error" class="mb-4">
+          {{ error }}
+        </v-alert>
+
+        <v-card v-else-if="article">
+          <v-card-title>{{ article.title }}</v-card-title>
+          <v-card-subtitle>Author: {{ article.author?.name }}</v-card-subtitle>
+          <v-card-subtitle>{{ formattedDate }}に公開</v-card-subtitle>
+          <v-card-text style="white-space: pre-wrap">{{
+            article.content
+          }}</v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, watch } from 'vue'
 import { useDateFormat } from '@vueuse/core'
 import { api } from '@/api/client'
 import type { ServerGetArticleJSONResponse } from '@/api/generated/apiSchema'
@@ -19,17 +19,23 @@ const formattedDate = useDateFormat(
   'YYYY/MM/DD',
 )
 
-onMounted(async () => {
-  loading.value = true
-  try {
-    const response = await api.api.articlesDetail(props.articleId)
-    article.value = response.data
-  } catch {
-    error.value = '記事の取得に失敗しました'
-  } finally {
-    loading.value = false
-  }
-})
+watch(
+  () => props.articleId,
+  async (id) => {
+    article.value = null
+    error.value = null
+    loading.value = true
+    try {
+      const response = await api.api.articlesDetail(id)
+      article.value = response.data
+    } catch {
+      error.value = '記事の取得に失敗しました'
+    } finally {
+      loading.value = false
+    }
+  },
+  { immediate: true },
+)
 </script>
 
 <template>

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -33,26 +33,35 @@ onMounted(async () => {
 </script>
 
 <template>
-  <v-container class="py-8">
-    <v-row justify="center">
-      <v-col cols="12" md="8" lg="6">
-        <div v-if="loading" class="d-flex justify-center py-12">
-          <v-progress-circular indeterminate color="primary" />
-        </div>
+  <v-sheet color="grey-lighten-4" min-height="100%">
+    <v-container class="py-12">
+      <v-row justify="center">
+        <v-col cols="12" md="8" lg="7">
+          <div v-if="loading" class="d-flex justify-center py-12">
+            <v-progress-circular indeterminate color="primary" />
+          </div>
 
-        <v-alert v-else-if="error" type="error" class="mb-4">
-          {{ error }}
-        </v-alert>
+          <v-alert v-else-if="error" type="error">
+            {{ error }}
+          </v-alert>
 
-        <v-card v-else-if="article">
-          <v-card-title>{{ article.title }}</v-card-title>
-          <v-card-subtitle>Author: {{ article.author?.name }}</v-card-subtitle>
-          <v-card-subtitle>{{ formattedDate }}に公開</v-card-subtitle>
-          <v-card-text style="white-space: pre-wrap">{{
-            article.content
-          }}</v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-container>
+          <template v-else-if="article">
+            <h1 class="text-h4 font-weight-bold mb-4">
+              {{ article.title }}
+            </h1>
+            <div class="text-body-2 text-medium-emphasis mb-6">
+              <div>著者 {{ article.author?.name }}</div>
+              <div>投稿日 {{ formattedDate }}</div>
+            </div>
+
+            <v-card flat rounded="lg" class="pa-8">
+              <div class="text-body-1" style="white-space: pre-wrap">
+                {{ article.content }}
+              </div>
+            </v-card>
+          </template>
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-sheet>
 </template>

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -31,6 +31,11 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/articles/:articleId(\\d+)',
+      component: () => import('@/features/articles/ArticleDetailView.vue'),
+      props: (route) => ({ articleId: Number(route.params.articleId) }),
+    },
+    {
       path: '/not-found',
       name: 'not-found',
       component: () => import('@/features/errors/ErrorStatusView.vue'),


### PR DESCRIPTION
## やったこと
- apiSchemaを使用してAPIの繋ぎ込みを作成
- 記事一覧画面の記事カードから記事詳細画面に飛べる
- 記事詳細画面を作成
  - タイトル、著者、投稿日を背景色の箇所に表示
  - 記事の内容は背景色を白色にして表示
- 記事の内容はDBの改行をそのまま維持するように

## 動作確認
- 記事一覧画面の記事カードから記事詳細画面にとべる

- <img width="1470" height="920" alt="image" src="https://github.com/user-attachments/assets/30491fe9-be80-432f-9547-df7f55acea87" />

