### PR TITLE
記事一覧画面と記事詳細画面にtag表示UIを追加_#124

### DIFF
--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -27,6 +27,7 @@ export interface ServerArticleJSONResponse {
   updated_at: string;
   user_id: number;
   likes_count?: number
+  tags?: ServerTagJSONResponse[];
 }
 
 export interface ServerCreateArticleRequest {
@@ -41,7 +42,8 @@ export interface ServerGetArticleJSONResponse {
   id: number;
   title: string;
   updated_at: string;
-  likes_count?: number
+  likes_count?: number;
+  tags?: ServerTagJSONResponse[];
 }
 
 export interface ServerListArticlesResponse {

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -19,6 +19,11 @@ export interface ServerArticleErrorResponse {
   message?: string;
 }
 
+export interface ServerTagJSONResponse {
+  id: number;
+  name: string;
+}
+
 export interface ServerArticleJSONResponse {
   content: string;
   created_at: string;

--- a/app/src/features/articles/ArticleCard.vue
+++ b/app/src/features/articles/ArticleCard.vue
@@ -4,6 +4,10 @@ import type { ServerArticleJSONResponse } from '@/api/generated/apiSchema'
 
 const props = defineProps<{ article: ServerArticleJSONResponse }>()
 
+const emit = defineEmits<{
+  (e: 'select-tag', tagName: string): void
+}>()
+
 const formattedDate = useDateFormat(
   () => props.article.created_at,
   'YYYY/MM/DD',
@@ -16,18 +20,25 @@ const formattedDate = useDateFormat(
       {{ article.title }}
     </v-card-title>
 
-    <v-card-subtitle
-      class="text-sm text-gray-500 d-flex align-center justify-space-between"
-    >
-      <span>{{ formattedDate }}</span>
+    <v-card-text v-if="article.tags?.length" class="py-0 px-4">
+      <v-chip-group>
+        <v-chip
+          v-for="tag in article.tags"
+          :key="tag.id"
+          size="x-small"
+          variant="outlined"
+          color="primary"
+          @click.stop.prevent="emit('select-tag', tag.name)"
+        >
+          {{ tag.name }}
+        </v-chip>
+      </v-chip-group>
+    </v-card-text>
 
+    <v-card-subtitle class="text-sm text-gray-500 d-flex align-center justify-space-between mt-2">
+      <span>{{ formattedDate }}</span>
       <div class="d-flex align-center">
-        <v-icon
-          icon="mdi-heart-outline"
-          size="small"
-          color="red-lighten-2"
-          class="me-1"
-        />
+        <v-icon icon="mdi-heart-outline" size="small" color="red-lighten-2" class="me-1" />
         <span>{{ article.likes_count ?? 0 }}</span>
       </div>
     </v-card-subtitle>

--- a/app/src/features/articles/ArticleCard.vue
+++ b/app/src/features/articles/ArticleCard.vue
@@ -10,7 +10,7 @@ const emit = defineEmits<{
 
 const formattedDate = useDateFormat(
   () => props.article.created_at ?? '',
-  'YYYY/MM/DD'
+  'YYYY/MM/DD',
 )
 </script>
 

--- a/app/src/features/articles/ArticleCard.vue
+++ b/app/src/features/articles/ArticleCard.vue
@@ -9,8 +9,8 @@ const emit = defineEmits<{
 }>()
 
 const formattedDate = useDateFormat(
-  () => props.article.created_at,
-  'YYYY/MM/DD',
+  () => props.article.created_at ?? '',
+  'YYYY/MM/DD'
 )
 </script>
 
@@ -35,10 +35,18 @@ const formattedDate = useDateFormat(
       </v-chip-group>
     </v-card-text>
 
-    <v-card-subtitle class="text-sm text-gray-500 d-flex align-center justify-space-between mt-2">
+    <v-card-subtitle
+      class="text-sm text-gray-500 d-flex align-center justify-space-between mt-2"
+    >
       <span>{{ formattedDate }}</span>
+
       <div class="d-flex align-center">
-        <v-icon icon="mdi-heart-outline" size="small" color="red-lighten-2" class="me-1" />
+        <v-icon
+          icon="mdi-heart-outline"
+          size="small"
+          color="red-lighten-2"
+          class="me-1"
+        />
         <span>{{ article.likes_count ?? 0 }}</span>
       </div>
     </v-card-subtitle>

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -4,37 +4,30 @@ import { useDateFormat } from '@vueuse/core'
 import { api } from '@/api/client'
 import type { ServerGetArticleJSONResponse } from '@/api/generated/apiSchema'
 
-defineOptions({
-  name: 'ArticleDetailView',
-})
+defineOptions({ name: 'ArticleDetailView' })
+
+interface ServerTagJSONResponse {
+  id: number
+  name: string
+}
 
 const props = defineProps<{ articleId: number }>()
-
 const article = ref<ServerGetArticleJSONResponse | null>(null)
 const loading = ref(false)
 const error = ref<string | null>(null)
-
 const isLiked = ref(false)
 
 const toggleLike = () => {
   if (!article.value) return
-
   isLiked.value = !isLiked.value
-
   if (isLiked.value) {
     article.value.likes_count = (article.value.likes_count ?? 0) + 1
   } else {
-    article.value.likes_count = Math.max(
-      0,
-      (article.value.likes_count ?? 1) - 1,
-    )
+    article.value.likes_count = Math.max(0, (article.value.likes_count ?? 1) - 1)
   }
 }
 
-const formattedDate = useDateFormat(
-  () => article.value?.created_at,
-  'YYYY/MM/DD',
-)
+const formattedDate = useDateFormat(() => article.value?.created_at, 'YYYY/MM/DD')
 
 watch(
   () => props.articleId,
@@ -65,39 +58,36 @@ watch(
             <v-progress-circular indeterminate color="primary" />
           </div>
 
-          <v-alert v-else-if="error" type="error">
-            {{ error }}
-          </v-alert>
+          <v-alert v-else-if="error" type="error">{{ error }}</v-alert>
 
           <template v-else-if="article">
-            <h1 class="text-h4 font-weight-bold mb-4">
-              {{ article.title }}
-            </h1>
+            <h1 class="text-h4 font-weight-bold mb-4">{{ article.title }}</h1>
 
-            <div
-              class="text-body-2 text-medium-emphasis mb-6 d-flex align-center"
-            >
+            <div v-if="article.tags?.length" class="mb-4 d-flex flex-wrap ga-2">
+              <v-chip
+                v-for="tag in (article.tags as ServerTagJSONResponse[])"
+                :key="tag.id"
+                size="small"
+                color="primary"
+                variant="flat"
+                label
+              >
+                <v-icon start icon="mdi-tag-outline" size="x-small" />
+                {{ tag.name }}
+              </v-chip>
+            </div>
+
+            <div class="text-body-2 text-medium-emphasis mb-6 d-flex align-center">
               <div>
                 <div>著者 {{ article.author?.name }}</div>
                 <div>投稿日 {{ formattedDate }}</div>
               </div>
-
               <v-spacer />
               <div class="d-flex align-center">
-                <v-btn
-                  variant="text"
-                  icon
-                  color="red-lighten-2"
-                  @click="toggleLike"
-                >
-                  <v-icon
-                    :icon="isLiked ? 'mdi-heart' : 'mdi-heart-outline'"
-                    size="default"
-                  />
+                <v-btn variant="text" icon color="red-lighten-2" @click="toggleLike">
+                  <v-icon :icon="isLiked ? 'mdi-heart' : 'mdi-heart-outline'" />
                 </v-btn>
-                <span class="text-subtitle-1 ml-1">{{
-                  article.likes_count ?? 0
-                }}</span>
+                <span class="text-subtitle-1 ml-1">{{ article.likes_count ?? 0 }}</span>
               </div>
             </div>
             <v-card flat rounded="lg" class="pa-8">

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -6,12 +6,8 @@ import type { ServerGetArticleJSONResponse } from '@/api/generated/apiSchema'
 
 defineOptions({ name: 'ArticleDetailView' })
 
-interface ServerTagJSONResponse {
-  id: number
-  name: string
-}
-
 const props = defineProps<{ articleId: number }>()
+
 const article = ref<ServerGetArticleJSONResponse | null>(null)
 const loading = ref(false)
 const error = ref<string | null>(null)
@@ -19,15 +15,23 @@ const isLiked = ref(false)
 
 const toggleLike = () => {
   if (!article.value) return
+
   isLiked.value = !isLiked.value
+
   if (isLiked.value) {
     article.value.likes_count = (article.value.likes_count ?? 0) + 1
   } else {
-    article.value.likes_count = Math.max(0, (article.value.likes_count ?? 1) - 1)
+    article.value.likes_count = Math.max(
+      0,
+      (article.value.likes_count ?? 1) - 1
+    )
   }
 }
 
-const formattedDate = useDateFormat(() => article.value?.created_at, 'YYYY/MM/DD')
+const formattedDate = useDateFormat(
+  () => article.value?.created_at ?? '',
+  'YYYY/MM/DD'
+)
 
 watch(
   () => props.articleId,
@@ -36,16 +40,18 @@ watch(
     error.value = null
     loading.value = true
     isLiked.value = false
+
     try {
       const response = await api.api.articlesDetail(id)
       article.value = response.data
-    } catch {
-      error.value = '記事の取得に失敗しました'
+    } catch (e) {
+      error.value =
+        e instanceof Error ? e.message : '記事の取得に失敗しました'
     } finally {
       loading.value = false
     }
   },
-  { immediate: true },
+  { immediate: true }
 )
 </script>
 
@@ -54,18 +60,27 @@ watch(
     <v-container class="py-12">
       <v-row justify="center">
         <v-col cols="12" md="8" lg="7">
+
           <div v-if="loading" class="d-flex justify-center py-12">
             <v-progress-circular indeterminate color="primary" />
           </div>
 
-          <v-alert v-else-if="error" type="error">{{ error }}</v-alert>
+          <v-alert v-else-if="error" type="error">
+            {{ error }}
+          </v-alert>
 
           <template v-else-if="article">
-            <h1 class="text-h4 font-weight-bold mb-4">{{ article.title }}</h1>
+            <h1 class="text-h4 font-weight-bold mb-4">
+              {{ article.title }}
+            </h1>
 
-            <div v-if="article.tags?.length" class="mb-4 d-flex flex-wrap ga-2">
+            <!-- ✅ cast削除（型推論OK） -->
+            <div
+              v-if="article.tags?.length"
+              class="mb-4 d-flex flex-wrap ga-2"
+            >
               <v-chip
-                v-for="tag in (article.tags as ServerTagJSONResponse[])"
+                v-for="tag in article.tags"
                 :key="tag.id"
                 size="small"
                 color="primary"
@@ -77,25 +92,41 @@ watch(
               </v-chip>
             </div>
 
-            <div class="text-body-2 text-medium-emphasis mb-6 d-flex align-center">
+            <div
+              class="text-body-2 text-medium-emphasis mb-6 d-flex align-center"
+            >
               <div>
                 <div>著者 {{ article.author?.name }}</div>
                 <div>投稿日 {{ formattedDate }}</div>
               </div>
+
               <v-spacer />
+
               <div class="d-flex align-center">
-                <v-btn variant="text" icon color="red-lighten-2" @click="toggleLike">
-                  <v-icon :icon="isLiked ? 'mdi-heart' : 'mdi-heart-outline'" />
+                <v-btn
+                  variant="text"
+                  icon
+                  color="red-lighten-2"
+                  @click="toggleLike"
+                >
+                  <v-icon
+                    :icon="isLiked ? 'mdi-heart' : 'mdi-heart-outline'"
+                  />
                 </v-btn>
-                <span class="text-subtitle-1 ml-1">{{ article.likes_count ?? 0 }}</span>
+
+                <span class="text-subtitle-1 ml-1">
+                  {{ article.likes_count ?? 0 }}
+                </span>
               </div>
             </div>
+
             <v-card flat rounded="lg" class="pa-8">
               <div class="text-body-1" style="white-space: pre-wrap">
                 {{ article.content }}
               </div>
             </v-card>
           </template>
+
         </v-col>
       </v-row>
     </v-container>

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -44,8 +44,8 @@ watch(
     try {
       const response = await api.api.articlesDetail(id)
       article.value = response.data
-    } catch (e) {
-      error.value = e instanceof Error ? e.message : '記事の取得に失敗しました'
+    } catch {
+      error.value = '記事の取得に失敗しました。時間をおいて再度お試しください。'
     } finally {
       loading.value = false
     }
@@ -72,7 +72,6 @@ watch(
               {{ article.title }}
             </h1>
 
-            <!-- ✅ cast削除（型推論OK） -->
             <div v-if="article.tags?.length" class="mb-4 d-flex flex-wrap ga-2">
               <v-chip
                 v-for="tag in article.tags"

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -23,14 +23,14 @@ const toggleLike = () => {
   } else {
     article.value.likes_count = Math.max(
       0,
-      (article.value.likes_count ?? 1) - 1
+      (article.value.likes_count ?? 1) - 1,
     )
   }
 }
 
 const formattedDate = useDateFormat(
   () => article.value?.created_at ?? '',
-  'YYYY/MM/DD'
+  'YYYY/MM/DD',
 )
 
 watch(
@@ -45,13 +45,12 @@ watch(
       const response = await api.api.articlesDetail(id)
       article.value = response.data
     } catch (e) {
-      error.value =
-        e instanceof Error ? e.message : '記事の取得に失敗しました'
+      error.value = e instanceof Error ? e.message : '記事の取得に失敗しました'
     } finally {
       loading.value = false
     }
   },
-  { immediate: true }
+  { immediate: true },
 )
 </script>
 
@@ -60,7 +59,6 @@ watch(
     <v-container class="py-12">
       <v-row justify="center">
         <v-col cols="12" md="8" lg="7">
-
           <div v-if="loading" class="d-flex justify-center py-12">
             <v-progress-circular indeterminate color="primary" />
           </div>
@@ -75,10 +73,7 @@ watch(
             </h1>
 
             <!-- ✅ cast削除（型推論OK） -->
-            <div
-              v-if="article.tags?.length"
-              class="mb-4 d-flex flex-wrap ga-2"
-            >
+            <div v-if="article.tags?.length" class="mb-4 d-flex flex-wrap ga-2">
               <v-chip
                 v-for="tag in article.tags"
                 :key="tag.id"
@@ -109,9 +104,7 @@ watch(
                   color="red-lighten-2"
                   @click="toggleLike"
                 >
-                  <v-icon
-                    :icon="isLiked ? 'mdi-heart' : 'mdi-heart-outline'"
-                  />
+                  <v-icon :icon="isLiked ? 'mdi-heart' : 'mdi-heart-outline'" />
                 </v-btn>
 
                 <span class="text-subtitle-1 ml-1">
@@ -126,7 +119,6 @@ watch(
               </div>
             </v-card>
           </template>
-
         </v-col>
       </v-row>
     </v-container>

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -38,10 +38,8 @@ const filteredArticles = computed(() => {
 
   return articles.value.filter((article) =>
     selectedTags.value.every((tagName) =>
-      article.tags?.some((tag: Tag) =>
-        tag.name === tagName
-      )
-    )
+      article.tags?.some((tag: Tag) => tag.name === tagName),
+    ),
   )
 })
 
@@ -55,20 +53,17 @@ onMounted(async () => {
     const response = await api.api.articlesList()
     articles.value = response.data.articles ?? []
   } catch (e) {
-    error.value =
-      e instanceof Error ? e.message : '記事の取得に失敗しました'
+    error.value = e instanceof Error ? e.message : '記事の取得に失敗しました'
   } finally {
     loading.value = false
   }
 })
 </script>
 
-
 <template>
   <v-container class="py-8">
     <v-row justify="center">
       <v-col cols="12" md="8" lg="6">
-
         <v-alert
           v-if="showCreatedAlert"
           type="success"
@@ -97,7 +92,6 @@ onMounted(async () => {
               {{ tag }}
             </v-chip>
 
-            
             <v-icon
               icon="mdi-close-circle"
               size="small"
@@ -105,7 +99,6 @@ onMounted(async () => {
               class="cursor-pointer ms-2"
               @click="clearTag"
             />
-
           </div>
         </v-fade-transition>
 
@@ -118,7 +111,6 @@ onMounted(async () => {
         </v-alert>
 
         <div v-else class="d-flex flex-column ga-4">
-
           <ArticleCard
             v-for="article in filteredArticles"
             :key="article.id"
@@ -133,7 +125,6 @@ onMounted(async () => {
           >
             該当する記事はありません
           </v-alert>
-
         </div>
       </v-col>
     </v-row>

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -5,10 +5,7 @@ import type { ServerArticleJSONResponse } from '@/api/generated/apiSchema'
 import { api } from '@/api/client'
 import { useArticleNotificationStore } from '@/stores/articleNotification'
 
-type Tag = {
-  id: number
-  name: string
-}
+type ArticleTag = NonNullable<ServerArticleJSONResponse['tags']>[number]
 
 const articles = ref<ServerArticleJSONResponse[]>([])
 const loading = ref(false)
@@ -38,7 +35,7 @@ const filteredArticles = computed(() => {
 
   return articles.value.filter((article) =>
     selectedTags.value.every((tagName) =>
-      article.tags?.some((tag: Tag) => tag.name === tagName),
+      article.tags?.some((tag: ArticleTag) => tag.name === tagName),
     ),
   )
 })
@@ -52,8 +49,8 @@ onMounted(async () => {
   try {
     const response = await api.api.articlesList()
     articles.value = response.data.articles ?? []
-  } catch (e) {
-    error.value = e instanceof Error ? e.message : '記事の取得に失敗しました'
+  } catch {
+    error.value = '記事の取得に失敗しました。時間をおいて再度お試しください。'
   } finally {
     loading.value = false
   }
@@ -92,11 +89,13 @@ onMounted(async () => {
               {{ tag }}
             </v-chip>
 
-            <v-icon
+            <v-btn
+              aria-label="絞り込みをすべて解除"
               icon="mdi-close-circle"
               size="small"
               color="grey"
-              class="cursor-pointer ms-2"
+              variant="text"
+              class="ms-1"
               @click="clearTag"
             />
           </div>

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -5,23 +5,45 @@ import type { ServerArticleJSONResponse } from '@/api/generated/apiSchema'
 import { api } from '@/api/client'
 import { useArticleNotificationStore } from '@/stores/articleNotification'
 
+type Tag = {
+  id: number
+  name: string
+}
+
 const articles = ref<ServerArticleJSONResponse[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
+
 const showCreatedAlert = ref(false)
 const notificationStore = useArticleNotificationStore()
-const selectedTag = ref<string | null>(null)
 
-const filteredArticles = computed(() => {
-  if (!selectedTag.value) return articles.value
-  return articles.value.filter((article) =>
-    article.tags?.some((tag: { name: string }) => tag.name === selectedTag.value)
-  )
-})
+const selectedTags = ref<string[]>([])
+
+const toggleTag = (tagName: string) => {
+  const index = selectedTags.value.indexOf(tagName)
+
+  if (index === -1) {
+    selectedTags.value.push(tagName)
+  } else {
+    selectedTags.value.splice(index, 1)
+  }
+}
 
 const clearTag = () => {
-  selectedTag.value = null
+  selectedTags.value = []
 }
+
+const filteredArticles = computed(() => {
+  if (selectedTags.value.length === 0) return articles.value
+
+  return articles.value.filter((article) =>
+    selectedTags.value.every((tagName) =>
+      article.tags?.some((tag: Tag) =>
+        tag.name === tagName
+      )
+    )
+  )
+})
 
 onMounted(async () => {
   if (notificationStore.consumeCreated()) {
@@ -32,18 +54,21 @@ onMounted(async () => {
   try {
     const response = await api.api.articlesList()
     articles.value = response.data.articles ?? []
-  } catch {
-    error.value = '記事の取得に失敗しました'
+  } catch (e) {
+    error.value =
+      e instanceof Error ? e.message : '記事の取得に失敗しました'
   } finally {
     loading.value = false
   }
 })
 </script>
 
+
 <template>
   <v-container class="py-8">
     <v-row justify="center">
       <v-col cols="12" md="8" lg="6">
+
         <v-alert
           v-if="showCreatedAlert"
           type="success"
@@ -55,11 +80,32 @@ onMounted(async () => {
         </v-alert>
 
         <v-fade-transition>
-          <div v-if="selectedTag" class="mb-4 d-flex align-center">
+          <div
+            v-if="selectedTags.length"
+            class="mb-4 d-flex align-center flex-wrap ga-2"
+          >
             <span class="text-subtitle-2 me-2">絞り込み中:</span>
-            <v-chip closable color="primary" label @click:close="clearTag">
-              {{ selectedTag }}
+
+            <v-chip
+              v-for="tag in selectedTags"
+              :key="tag"
+              closable
+              color="primary"
+              label
+              @click:close="toggleTag(tag)"
+            >
+              {{ tag }}
             </v-chip>
+
+            
+            <v-icon
+              icon="mdi-close-circle"
+              size="small"
+              color="grey"
+              class="cursor-pointer ms-2"
+              @click="clearTag"
+            />
+
           </div>
         </v-fade-transition>
 
@@ -72,16 +118,22 @@ onMounted(async () => {
         </v-alert>
 
         <div v-else class="d-flex flex-column ga-4">
+
           <ArticleCard
             v-for="article in filteredArticles"
             :key="article.id"
             :article="article"
-            @select-tag="selectedTag = $event"
+            @select-tag="toggleTag"
           />
 
-          <v-alert v-if="filteredArticles.length === 0" type="info" variant="tonal">
+          <v-alert
+            v-if="filteredArticles.length === 0"
+            type="info"
+            variant="tonal"
+          >
             該当する記事はありません
           </v-alert>
+
         </div>
       </v-col>
     </v-row>

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -1,15 +1,27 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import ArticleCard from './ArticleCard.vue'
-import type { Article } from './types'
+import type { ServerArticleJSONResponse } from '@/api/generated/apiSchema'
 import { api } from '@/api/client'
 import { useArticleNotificationStore } from '@/stores/articleNotification'
 
-const articles = ref<Article[]>([])
+const articles = ref<ServerArticleJSONResponse[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
 const showCreatedAlert = ref(false)
 const notificationStore = useArticleNotificationStore()
+const selectedTag = ref<string | null>(null)
+
+const filteredArticles = computed(() => {
+  if (!selectedTag.value) return articles.value
+  return articles.value.filter((article) =>
+    article.tags?.some((tag: { name: string }) => tag.name === selectedTag.value)
+  )
+})
+
+const clearTag = () => {
+  selectedTag.value = null
+}
 
 onMounted(async () => {
   if (notificationStore.consumeCreated()) {
@@ -42,6 +54,15 @@ onMounted(async () => {
           記事を投稿しました
         </v-alert>
 
+        <v-fade-transition>
+          <div v-if="selectedTag" class="mb-4 d-flex align-center">
+            <span class="text-subtitle-2 me-2">絞り込み中:</span>
+            <v-chip closable color="primary" label @click:close="clearTag">
+              {{ selectedTag }}
+            </v-chip>
+          </div>
+        </v-fade-transition>
+
         <div v-if="loading" class="d-flex justify-center py-12">
           <v-progress-circular indeterminate color="primary" />
         </div>
@@ -52,10 +73,15 @@ onMounted(async () => {
 
         <div v-else class="d-flex flex-column ga-4">
           <ArticleCard
-            v-for="article in articles"
+            v-for="article in filteredArticles"
             :key="article.id"
             :article="article"
+            @select-tag="selectedTag = $event"
           />
+
+          <v-alert v-if="filteredArticles.length === 0" type="info" variant="tonal">
+            該当する記事はありません
+          </v-alert>
         </div>
       </v-col>
     </v-row>


### PR DESCRIPTION
## やったこと
- 記事詳細画面にタグ表示UIの追加
- 記事一覧画面にタグ表示UIの追加と絞り込み機能の追加

## 動作確認
- これはテストデータを入れ込んだ画像です。
- pushしたファイルにはテストデータはありません
<img width="1919" height="997" alt="スクリーンショット 2026-05-08 104802" src="https://github.com/user-attachments/assets/3250db18-78c6-416a-b227-8ea80324b9a7" />
<img width="1919" height="997" alt="スクリーンショット 2026-05-08 104821" src="https://github.com/user-attachments/assets/e94c124f-59c0-4edc-8c8f-c34e33921966" />
