### PR TITLE
feat: いいねのシードデータを追加

### DIFF
--- a/api/migrations/20260510170000_seed_likes.down.sql
+++ b/api/migrations/20260510170000_seed_likes.down.sql
@@ -1,0 +1,22 @@
+-- 上記 seed で投入した (article, user) の組み合わせのみを削除する。
+-- ユーザーが手動で押した本物のいいねを巻き込まないよう、組み合わせを明示する。
+DELETE FROM likes l
+USING articles a, users u
+WHERE l.article_id = a.id
+  AND l.user_id    = u.id
+  AND (a.title, u.name) IN (
+    ('神戸大学でのハッカソン体験記',          'user01'),
+    ('神戸大学でのハッカソン体験記',          'user02'),
+    ('神戸大学でのハッカソン体験記',          'user03'),
+    ('Goで作るREST API入門',                  'admin'),
+    ('Goで作るREST API入門',                  'user02'),
+    ('Goで作るREST API入門',                  'user03'),
+    ('Vue 3 + Vuetifyで学ぶフロントエンド開発', 'admin'),
+    ('Vue 3 + Vuetifyで学ぶフロントエンド開発', 'user01'),
+    ('Vue 3 + Vuetifyで学ぶフロントエンド開発', 'user03'),
+    ('PostgreSQLのマイグレーション管理',      'admin'),
+    ('PostgreSQLのマイグレーション管理',      'user01'),
+    ('Dockerで開発環境を統一する',            'admin'),
+    ('Dockerで開発環境を統一する',            'user02'),
+    ('Dockerで開発環境を統一する',            'user03')
+  );

--- a/api/migrations/20260510170000_seed_likes.up.sql
+++ b/api/migrations/20260510170000_seed_likes.up.sql
@@ -1,0 +1,25 @@
+-- likes の seed
+-- 「自分がいいねした記事」「他人もいいねしている記事」が動作確認画面で
+-- 同時に見えるように、各ユーザーが複数の記事へまたがっていいねしている状態を作る。
+-- 自分の記事に自分でいいねは付けない。
+INSERT INTO likes (article_id, user_id, created_at, updated_at)
+SELECT a.id, u.id, v.created_at, v.updated_at
+FROM (VALUES
+    ('神戸大学でのハッカソン体験記',          'user01', '2026-04-02 10:00:00+09'::timestamptz, '2026-04-02 10:00:00+09'::timestamptz),
+    ('神戸大学でのハッカソン体験記',          'user02', '2026-04-02 11:00:00+09'::timestamptz, '2026-04-02 11:00:00+09'::timestamptz),
+    ('神戸大学でのハッカソン体験記',          'user03', '2026-04-02 12:00:00+09'::timestamptz, '2026-04-02 12:00:00+09'::timestamptz),
+    ('Goで作るREST API入門',                  'admin',  '2026-04-11 09:00:00+09'::timestamptz, '2026-04-11 09:00:00+09'::timestamptz),
+    ('Goで作るREST API入門',                  'user02', '2026-04-11 10:30:00+09'::timestamptz, '2026-04-11 10:30:00+09'::timestamptz),
+    ('Goで作るREST API入門',                  'user03', '2026-04-12 13:00:00+09'::timestamptz, '2026-04-12 13:00:00+09'::timestamptz),
+    ('Vue 3 + Vuetifyで学ぶフロントエンド開発', 'admin',  '2026-04-16 09:00:00+09'::timestamptz, '2026-04-16 09:00:00+09'::timestamptz),
+    ('Vue 3 + Vuetifyで学ぶフロントエンド開発', 'user01', '2026-04-16 11:00:00+09'::timestamptz, '2026-04-16 11:00:00+09'::timestamptz),
+    ('Vue 3 + Vuetifyで学ぶフロントエンド開発', 'user03', '2026-04-17 14:00:00+09'::timestamptz, '2026-04-17 14:00:00+09'::timestamptz),
+    ('PostgreSQLのマイグレーション管理',      'admin',  '2026-04-19 09:00:00+09'::timestamptz, '2026-04-19 09:00:00+09'::timestamptz),
+    ('PostgreSQLのマイグレーション管理',      'user01', '2026-04-19 12:00:00+09'::timestamptz, '2026-04-19 12:00:00+09'::timestamptz),
+    ('Dockerで開発環境を統一する',            'admin',  '2026-04-20 13:00:00+09'::timestamptz, '2026-04-20 13:00:00+09'::timestamptz),
+    ('Dockerで開発環境を統一する',            'user02', '2026-04-21 09:00:00+09'::timestamptz, '2026-04-21 09:00:00+09'::timestamptz),
+    ('Dockerで開発環境を統一する',            'user03', '2026-04-21 15:00:00+09'::timestamptz, '2026-04-21 15:00:00+09'::timestamptz)
+) AS v(article_title, user_name, created_at, updated_at)
+JOIN articles a ON a.title = v.article_title
+JOIN users u    ON u.name  = v.user_name
+ON CONFLICT (article_id, user_id) DO NOTHING;


### PR DESCRIPTION
## Summary

- `likes` テーブル用の seed migration を追加（14 件、各ユーザーが自分以外の複数記事へまたがっていいね済み）
- 既存 `seed_articles` に揃えて、`JOIN articles/users` でタイトル・名前から id 解決し、`ON CONFLICT (article_id, user_id) DO NOTHING` で冪等性を担保
- down は `(title, name) IN (...)` で seed 由来のみを巻き取り、開発中に手動で押した本物のいいねを消さないようにしている

## なぜこの seed が必要か

UX バグの再現/動作確認に \"自分がいいね済み\" / \"未いいね\" / \"他人もいいねしている\" が同じ画面で見える状態が必要。admin にも複数いいねを付与してあるので、メイン確認アカウントが admin であればそのまま検証できる。

## スコープ外（別 issue に切り出し済み）

シード投入後に表面化する以下の UX バグはこの PR には含めない。API 側に \`liked_by_me\` を追加する根本対応が必要なため、別ブランチ/別 PR で対応する。

- リロードでいいね済み状態が消える
- 一覧（ArticleCard）が常にアウトライン固定
- 既いいね記事を再度押すと「アイコンは塗りつぶしになるがカウントが増えない」（409 ハンドリング）

→ #160 で対応予定

## Test plan

- [ ] `make db-up` でコンテナ起動
- [ ] マイグレーション up で seed が入ること
- [ ] 一覧 (`/articles`) を未認証で開いて 5 記事表示
- [ ] admin でログイン → 詳細を開いて `likes_count` が seed の数になっていること（例: 神戸大学でのハッカソン体験記 = 3）
- [ ] migrate down 1 で seed が消え、手動で押したいいねは残ること