### PR TITLE
feat:Reply の質問・回答対応とコンポーネントリネーム

### DIFF
--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -5,7 +5,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useDateFormat } from '@vueuse/core'
 import { api } from '@/api/client'
 import type { ServerGetArticleJSONResponse } from '@/api/generated/apiSchema'
-import CommentSection from '@/features/comments/CommentSection.vue'
+import ReplySection from '@/features/replies/ReplySection.vue'
 import { useAuthStore } from '@/stores/auth'
 
 defineOptions({ name: 'ArticleDetailView' })
@@ -156,7 +156,7 @@ watch(
             </v-card>
 
             <div class="mt-10">
-              <CommentSection :article-id="article.id" />
+              <ReplySection :article-id="article.id" />
             </div>
           </template>
         </v-col>

--- a/app/src/features/replies/ReplyForm.vue
+++ b/app/src/features/replies/ReplyForm.vue
@@ -3,29 +3,45 @@ import { computed, ref } from 'vue'
 import { api } from '@/api/client'
 import type { ServerReplyJSONResponse } from '@/api/generated/apiSchema'
 
+type ReplyKind = 'comment' | 'question' | 'answer'
+
 defineOptions({
-  name: 'CommentForm',
+  name: 'ReplyForm',
 })
 
 const props = defineProps<{
   articleId: number
   parentId: number | null
+  parentKind: ReplyKind | null
   autofocus?: boolean
 }>()
 
 const emit = defineEmits<{
-  (e: 'submitted', comment: ServerReplyJSONResponse): void
+  (e: 'submitted', reply: ServerReplyJSONResponse): void
 }>()
 
 const body = ref('')
 const submitting = ref(false)
 const submitError = ref<string | null>(null)
 
-const canSubmit = computed(() => !submitting.value && !!body.value.trim())
+// 記事直下投稿のときだけユーザーが選べる。返信時は親 kind から自動導出する。
+const selectedKind = ref<'comment' | 'question'>('comment')
 
-const placeholder = computed(() =>
-  props.parentId === null ? 'コメントを書く' : 'このコメントに返信する',
-)
+const resolvedKind = computed<ReplyKind>(() => {
+  if (props.parentKind === null) return selectedKind.value
+  if (props.parentKind === 'comment') return 'comment'
+  return 'answer'
+})
+
+const placeholder = computed(() => {
+  if (props.parentKind === null) {
+    return selectedKind.value === 'question' ? '質問を書く' : 'コメントを書く'
+  }
+  if (props.parentKind === 'comment') return 'このコメントに返信する'
+  return '回答を書く'
+})
+
+const canSubmit = computed(() => !submitting.value && !!body.value.trim())
 
 const submit = async () => {
   if (submitting.value) return
@@ -39,7 +55,7 @@ const submit = async () => {
       props.articleId,
       {
         parent_id: props.parentId ?? undefined,
-        kind: 'comment',
+        kind: resolvedKind.value,
         body: body.value,
       },
       { skipGlobalErrorHandler: true },
@@ -65,6 +81,17 @@ const submit = async () => {
     >
       {{ submitError }}
     </v-alert>
+
+    <v-btn-toggle
+      v-if="parentKind === null"
+      v-model="selectedKind"
+      mandatory
+      density="comfortable"
+      color="primary"
+    >
+      <v-btn value="comment">コメント</v-btn>
+      <v-btn value="question">質問</v-btn>
+    </v-btn-toggle>
 
     <v-textarea
       v-model="body"

--- a/app/src/features/replies/ReplyItem.vue
+++ b/app/src/features/replies/ReplyItem.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useTimeAgo, type UseTimeAgoMessages } from '@vueuse/core'
 import type { ServerReplyJSONResponse } from '@/api/generated/apiSchema'
 
 defineOptions({
-  name: 'CommentItem',
+  name: 'ReplyItem',
 })
 
 const props = defineProps<{
-  comment: ServerReplyJSONResponse
+  reply: ServerReplyJSONResponse
   canReply: boolean
   replying: boolean
 }>()
@@ -16,9 +17,26 @@ defineEmits<{
   (e: 'toggle-reply'): void
 }>()
 
+const kindBadge = computed(() => {
+  switch (props.reply.kind) {
+    case 'question':
+      return { color: 'warning', label: '質問' }
+    case 'answer':
+      return { color: 'success', label: '回答' }
+    default:
+      return { color: 'primary', label: 'コメント' }
+  }
+})
+
+// 返信ボタン文言は親（=この reply）の kind から決める。
+// コメント配下は「コメントする」、質問/回答配下は「回答する」。
+const replyActionLabel = computed(() =>
+  props.reply.kind === 'comment' ? 'コメントする' : '回答する',
+)
+
 // 投稿から 6 日以内は「N分前 / N時間前 / N日前」と表示し、7 日以上経過したら絶対日付に切り替える。
 // useTimeAgo は内部で setInterval により値をリアクティブに更新するので、画面を開きっぱなしでも表示が古びない。
-const formattedDate = useTimeAgo(() => props.comment.created_at, {
+const formattedDate = useTimeAgo(() => props.reply.created_at, {
   max: 6 * 24 * 60 * 60 * 1000,
   fullDateFormatter: (date) => {
     const y = date.getFullYear()
@@ -47,11 +65,11 @@ const formattedDate = useTimeAgo(() => props.comment.created_at, {
 <template>
   <v-card flat rounded="lg" class="pa-4 bg-grey-lighten-5">
     <div class="d-flex align-center ga-2 mb-2">
-      <v-chip color="primary" size="small" variant="tonal" label>
-        コメント
+      <v-chip :color="kindBadge.color" size="small" variant="tonal" label>
+        {{ kindBadge.label }}
       </v-chip>
       <span class="text-body-2 font-weight-medium">
-        {{ comment.user_name }}
+        {{ reply.user_name }}
       </span>
       <span class="text-caption text-medium-emphasis">
         {{ formattedDate }}
@@ -59,7 +77,7 @@ const formattedDate = useTimeAgo(() => props.comment.created_at, {
     </div>
 
     <div class="text-body-2 mb-2" style="white-space: pre-wrap">
-      {{ comment.body }}
+      {{ reply.body }}
     </div>
 
     <div v-if="canReply" class="d-flex">
@@ -70,7 +88,7 @@ const formattedDate = useTimeAgo(() => props.comment.created_at, {
         :prepend-icon="replying ? 'mdi-close' : 'mdi-reply'"
         @click="$emit('toggle-reply')"
       >
-        {{ replying ? 'キャンセル' : 'コメントする' }}
+        {{ replying ? 'キャンセル' : replyActionLabel }}
       </v-btn>
     </div>
   </v-card>

--- a/app/src/features/replies/ReplySection.vue
+++ b/app/src/features/replies/ReplySection.vue
@@ -5,11 +5,11 @@ import { useRoute } from 'vue-router'
 import { api } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
 import type { ServerReplyJSONResponse } from '@/api/generated/apiSchema'
-import CommentForm from './CommentForm.vue'
-import CommentThread from './CommentThread.vue'
+import ReplyForm from './ReplyForm.vue'
+import ReplyThread from './ReplyThread.vue'
 
 defineOptions({
-  name: 'CommentSection',
+  name: 'ReplySection',
 })
 
 const props = defineProps<{ articleId: number }>()
@@ -20,17 +20,17 @@ const loginRedirect = computed(
   () => `/login?redirect=${encodeURIComponent(route.fullPath)}`,
 )
 
-const comments = ref<ServerReplyJSONResponse[]>([])
+const replies = ref<ServerReplyJSONResponse[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
 
 const childrenByParent = computed(() => {
   const map = new Map<number, ServerReplyJSONResponse[]>()
-  for (const c of comments.value) {
-    if (c.parent_id == null) continue
-    const list = map.get(c.parent_id) ?? []
-    list.push(c)
-    map.set(c.parent_id, list)
+  for (const r of replies.value) {
+    if (r.parent_id == null) continue
+    const list = map.get(r.parent_id) ?? []
+    list.push(r)
+    map.set(r.parent_id, list)
   }
   for (const list of map.values()) {
     list.sort(
@@ -41,7 +41,7 @@ const childrenByParent = computed(() => {
   return map
 })
 
-// 各コメントの「自分以下にぶら下がる返信の総数」をメモ化付き DFS で一括計算する。
+// 各リプライの「自分以下にぶら下がる返信の総数」をメモ化付き DFS で一括計算する。
 // 「返信 N 件を表示」ボタンは展開時にサブツリー全体を開く挙動なので、N もサブツリー全体の件数に揃える。
 const descendantCountByParent = computed(() => {
   const counts = new Map<number, number>()
@@ -54,13 +54,13 @@ const descendantCountByParent = computed(() => {
     counts.set(id, total)
     return total
   }
-  for (const c of comments.value) compute(c.id)
+  for (const r of replies.value) compute(r.id)
   return counts
 })
 
-const rootComments = computed(() =>
-  comments.value
-    .filter((c) => c.parent_id == null)
+const rootReplies = computed(() =>
+  replies.value
+    .filter((r) => r.parent_id == null)
     .slice()
     .sort(
       (a, b) =>
@@ -68,33 +68,30 @@ const rootComments = computed(() =>
     ),
 )
 
-const isCommentKind = (c: ServerReplyJSONResponse) => c.kind === 'comment'
-
-const fetchComments = async (id: number) => {
+const fetchReplies = async (id: number) => {
   loading.value = true
   error.value = null
   try {
     const { data } = await api.api.articlesRepliesList(id, {
       skipGlobalErrorHandler: true,
     })
-    comments.value = (data.replies ?? []).filter(isCommentKind)
+    replies.value = data.replies ?? []
   } catch {
-    error.value = 'コメントの取得に失敗しました'
+    error.value = 'リプライの取得に失敗しました'
   } finally {
     loading.value = false
   }
 }
 
-const handleSubmitted = (newComment: ServerReplyJSONResponse) => {
-  if (!isCommentKind(newComment)) return
-  comments.value = [...comments.value, newComment]
+const handleSubmitted = (newReply: ServerReplyJSONResponse) => {
+  replies.value = [...replies.value, newReply]
 }
 
 watch(
   () => props.articleId,
   (id) => {
-    comments.value = []
-    void fetchComments(id)
+    replies.value = []
+    void fetchReplies(id)
   },
   { immediate: true },
 )
@@ -103,22 +100,23 @@ watch(
 <template>
   <section class="d-flex flex-column ga-6">
     <h2 class="text-h6 font-weight-bold">
-      コメント
+      リプライ
       <span v-if="!loading" class="text-medium-emphasis text-body-2 ml-1">
-        ({{ comments.length }})
+        ({{ replies.length }})
       </span>
     </h2>
 
     <v-card flat rounded="lg" class="pa-4">
-      <CommentForm
+      <ReplyForm
         v-if="isAuthenticated"
         :article-id="articleId"
         :parent-id="null"
+        :parent-kind="null"
         @submitted="handleSubmitted"
       />
       <div v-else class="text-body-2 d-flex align-center ga-2">
         <v-icon icon="mdi-lock-outline" size="small" />
-        <span>コメントを投稿するには</span>
+        <span>リプライを投稿するには</span>
         <RouterLink :to="loginRedirect" class="text-primary">
           ログイン
         </RouterLink>
@@ -135,24 +133,24 @@ watch(
     <v-alert v-else-if="error" type="error" closable>
       {{ error }}
       <template #append>
-        <v-btn variant="text" size="small" @click="fetchComments(articleId)">
+        <v-btn variant="text" size="small" @click="fetchReplies(articleId)">
           再試行
         </v-btn>
       </template>
     </v-alert>
 
     <div
-      v-else-if="rootComments.length === 0"
+      v-else-if="rootReplies.length === 0"
       class="text-body-2 text-medium-emphasis text-center py-6"
     >
-      まだコメントはありません
+      まだリプライはありません
     </div>
 
     <div v-else class="d-flex flex-column ga-4">
-      <CommentThread
-        v-for="comment in rootComments"
-        :key="comment.id"
-        :comment="comment"
+      <ReplyThread
+        v-for="reply in rootReplies"
+        :key="reply.id"
+        :reply="reply"
         :children-by-parent="childrenByParent"
         :descendant-count-by-parent="descendantCountByParent"
         :depth="0"

--- a/app/src/features/replies/ReplyThread.vue
+++ b/app/src/features/replies/ReplyThread.vue
@@ -3,15 +3,15 @@ import { computed, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
 import type { ServerReplyJSONResponse } from '@/api/generated/apiSchema'
-import CommentItem from './CommentItem.vue'
-import CommentForm from './CommentForm.vue'
+import ReplyItem from './ReplyItem.vue'
+import ReplyForm from './ReplyForm.vue'
 
 defineOptions({
-  name: 'CommentThread',
+  name: 'ReplyThread',
 })
 
 const props = defineProps<{
-  comment: ServerReplyJSONResponse
+  reply: ServerReplyJSONResponse
   childrenByParent: Map<number, ServerReplyJSONResponse[]>
   descendantCountByParent: Map<number, number>
   depth: number
@@ -19,17 +19,17 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: 'submitted', comment: ServerReplyJSONResponse): void
+  (e: 'submitted', reply: ServerReplyJSONResponse): void
 }>()
 
 const { isAuthenticated } = storeToRefs(useAuthStore())
 
 const children = computed<ServerReplyJSONResponse[]>(
-  () => props.childrenByParent.get(props.comment.id) ?? [],
+  () => props.childrenByParent.get(props.reply.id) ?? [],
 )
 
 const descendantCount = computed(
-  () => props.descendantCountByParent.get(props.comment.id) ?? 0,
+  () => props.descendantCountByParent.get(props.reply.id) ?? 0,
 )
 
 // depth 0 のみ初期折りたたみ。クリックで自分以下のサブツリーをまとめて開く。
@@ -40,8 +40,8 @@ const toggleReplyForm = () => {
   showReplyForm.value = !showReplyForm.value
 }
 
-const handleSubmitted = (newComment: ServerReplyJSONResponse) => {
-  emit('submitted', newComment)
+const handleSubmitted = (newReply: ServerReplyJSONResponse) => {
+  emit('submitted', newReply)
   showReplyForm.value = false
   expanded.value = true
 }
@@ -49,17 +49,18 @@ const handleSubmitted = (newComment: ServerReplyJSONResponse) => {
 
 <template>
   <div class="d-flex flex-column ga-3">
-    <CommentItem
-      :comment="comment"
+    <ReplyItem
+      :reply="reply"
       :can-reply="isAuthenticated"
       :replying="showReplyForm"
       @toggle-reply="toggleReplyForm"
     />
 
     <div v-if="showReplyForm" class="ml-8">
-      <CommentForm
+      <ReplyForm
         :article-id="articleId"
-        :parent-id="comment.id"
+        :parent-id="reply.id"
+        :parent-kind="reply.kind"
         autofocus
         @submitted="handleSubmitted"
       />
@@ -67,10 +68,10 @@ const handleSubmitted = (newComment: ServerReplyJSONResponse) => {
 
     <div v-if="children.length > 0" class="ml-8">
       <div v-if="expanded" class="d-flex flex-column ga-3">
-        <CommentThread
+        <ReplyThread
           v-for="child in children"
           :key="child.id"
-          :comment="child"
+          :reply="child"
           :children-by-parent="childrenByParent"
           :descendant-count-by-parent="descendantCountByParent"
           :depth="depth + 1"


### PR DESCRIPTION
- features/comments を features/replies にリネーム
- 投稿フォームに種別選択トグル（コメント/質問）を追加
- 返信フォームの kind を親 kind から自動導出（comment→comment, question/answer→answer）
- 一覧の comment-only フィルタを撤去し、質問・回答も表示
- 種別バッジを primary/warning/success で色分け
- 返信ボタン文言を親 kind に応じて切り替え

めんどくさいから回答までやっちゃった

apiSchemaを参照しているため現在のバックエンドの実装がない場面では動作確認できない
一瞬ハードコードして対応


## 動作確認
<img width="709" height="340" alt="image" src="https://github.com/user-attachments/assets/b14723f9-092e-42a8-a75d-3cd8f42a47e0" />
<img width="718" height="340" alt="image" src="https://github.com/user-attachments/assets/8358ffb4-e6c7-4141-bd1b-92c1b33d8648" />

<img width="705" height="350" alt="image" src="https://github.com/user-attachments/assets/682b81b4-4ac8-4586-84a4-2b468e98ab36" />
<img width="728" height="410" alt="image" src="https://github.com/user-attachments/assets/09e6f114-18dc-4fb9-bc0b-6d8af399c9b4" />
<img width="725" height="358" alt="image" src="https://github.com/user-attachments/assets/3cc327df-fa4f-4b36-9b42-f94933c40b15" />
<img width="765" height="592" alt="image" src="https://github.com/user-attachments/assets/5fbaa7e4-9026-4971-9dbc-d20b7fe831c7" />



Closes #183