### PR TITLE
パスワード変更エンドポイント

### DIFF
--- a/api/internal/auth/handler/change_password.go
+++ b/api/internal/auth/handler/change_password.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/Baymax6s/KOBE-Tech/api/internal/auth"
@@ -11,8 +12,8 @@ import (
 )
 
 type ChangePasswordRequest struct {
-	CurrentPassword string `json:"current_password"`
-	NewPassword     string `json:"new_password"`
+	CurrentPassword string `json:"current_password" binding:"required"`
+	NewPassword     string `json:"new_password" binding:"required" minLength:"8"`
 } // @name server.changePasswordRequest
 
 type ChangePasswordResponse struct {
@@ -71,10 +72,10 @@ func (h *Handler) ChangePassword(ctx context.Context, userID int64, currentPassw
 	}
 
 	if currentPassword == "" || newPassword == "" {
-		return errors.Join(errPasswordValidation, errors.New("current_password and new_password are required"))
+		return fmt.Errorf("current_password and new_password are required: %w", errPasswordValidation)
 	}
 	if len(newPassword) < 8 {
-		return errors.Join(errPasswordValidation, errors.New("new_password must be at least 8 characters"))
+		return fmt.Errorf("new_password must be at least 8 characters: %w", errPasswordValidation)
 	}
 
 	user, err := h.repo.FindByID(ctx, userID)

--- a/api/internal/auth/handler/change_password.go
+++ b/api/internal/auth/handler/change_password.go
@@ -1,0 +1,98 @@
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+
+	"github.com/Baymax6s/KOBE-Tech/api/internal/auth"
+	"github.com/gin-gonic/gin"
+)
+
+type ChangePasswordRequest struct {
+	CurrentPassword string `json:"current_password"`
+	NewPassword     string `json:"new_password"`
+} // @name server.changePasswordRequest
+
+type ChangePasswordResponse struct {
+	Message string `json:"message"`
+} // @name server.changePasswordResponse
+
+type ChangePasswordErrorResponse struct {
+	Message string `json:"message"`
+} // @name server.changePasswordErrorResponse
+
+// changePasswordHandler godoc
+//
+//	@Summary		Change password
+//	@Description	Changes the authenticated user's password.
+//	@Tags			auth
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		ChangePasswordRequest	true	"Change password request"
+//	@Success		200		{object}	ChangePasswordResponse
+//	@Failure		400		{object}	ChangePasswordErrorResponse
+//	@Failure		401		{object}	ChangePasswordErrorResponse
+//	@Failure		500		{object}	ChangePasswordErrorResponse
+//	@Security		BearerAuth
+//	@Router			/api/auth/password [put]
+func (h *Handler) changePasswordHandler(c *gin.Context) {
+	var req ChangePasswordRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ChangePasswordErrorResponse{Message: "invalid request body"})
+		return
+	}
+
+	userID := auth.MustUserID(c)
+
+	err := h.ChangePassword(c.Request.Context(), userID, req.CurrentPassword, req.NewPassword)
+	if err != nil {
+		switch {
+		case errors.Is(err, errPasswordValidation):
+			c.JSON(http.StatusBadRequest, ChangePasswordErrorResponse{Message: err.Error()})
+		case errors.Is(err, errUserNotFound), errors.Is(err, errCurrentPasswordIncorrect):
+			c.JSON(http.StatusUnauthorized, ChangePasswordErrorResponse{Message: err.Error()})
+		default:
+			c.JSON(http.StatusInternalServerError, ChangePasswordErrorResponse{Message: "failed to change password"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, ChangePasswordResponse{Message: "パスワードを変更しました"})
+}
+
+var errPasswordValidation = errors.New("validation error")
+var errCurrentPasswordIncorrect = errors.New("current password is incorrect")
+
+func (h *Handler) ChangePassword(ctx context.Context, userID int64, currentPassword, newPassword string) error {
+	if h == nil || h.repo == nil {
+		return errors.New("auth handler is not configured")
+	}
+
+	if currentPassword == "" || newPassword == "" {
+		return errors.Join(errPasswordValidation, errors.New("current_password and new_password are required"))
+	}
+	if len(newPassword) < 8 {
+		return errors.Join(errPasswordValidation, errors.New("new_password must be at least 8 characters"))
+	}
+
+	user, err := h.repo.FindByID(ctx, userID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errUserNotFound
+		}
+		return err
+	}
+
+	if err := auth.ComparePassword(user.PasswordHash, currentPassword); err != nil {
+		return errCurrentPasswordIncorrect
+	}
+
+	newHash, err := auth.HashPassword(newPassword)
+	if err != nil {
+		return err
+	}
+
+	return h.repo.UpdatePassword(ctx, userID, newHash)
+}

--- a/api/internal/auth/handler/handler.go
+++ b/api/internal/auth/handler/handler.go
@@ -18,4 +18,5 @@ func NewHandler(repo *repository.Repository, issuer *auth.Issuer) *Handler {
 func (h *Handler) RegisterRoutes(router gin.IRouter, authRouter gin.IRouter) {
 	router.POST("/auth/login", h.loginHandler)
 	authRouter.GET("/auth/me", h.meHandler)
+	authRouter.PUT("/auth/password", h.changePasswordHandler)
 }

--- a/api/internal/auth/password.go
+++ b/api/internal/auth/password.go
@@ -5,3 +5,11 @@ import "golang.org/x/crypto/bcrypt"
 func ComparePassword(hash, password string) error {
 	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
 }
+
+func HashPassword(password string) (string, error) {
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 10)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}

--- a/api/internal/auth/repository/update_password.go
+++ b/api/internal/auth/repository/update_password.go
@@ -1,0 +1,21 @@
+package repository
+
+import (
+	"context"
+	"errors"
+)
+
+func (r *Repository) UpdatePassword(ctx context.Context, userID int64, passwordHash string) error {
+	if r == nil || r.db == nil {
+		return errors.New("auth repository is not configured")
+	}
+
+	const query = `
+		UPDATE users
+		SET password_hash = $1, updated_at = NOW()
+		WHERE id = $2
+	`
+
+	_, err := r.db.ExecContext(ctx, query, passwordHash, userID)
+	return err
+}

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -55,6 +55,23 @@ definitions:
     - id
     - name
     type: object
+  server.changePasswordErrorResponse:
+    properties:
+      message:
+        type: string
+    type: object
+  server.changePasswordRequest:
+    properties:
+      current_password:
+        type: string
+      new_password:
+        type: string
+    type: object
+  server.changePasswordResponse:
+    properties:
+      message:
+        type: string
+    type: object
   server.createArticleRequest:
     properties:
       content:
@@ -548,6 +565,42 @@ paths:
       security:
       - BearerAuth: []
       summary: Get current user
+      tags:
+      - auth
+  /api/auth/password:
+    put:
+      consumes:
+      - application/json
+      description: Changes the authenticated user's password.
+      parameters:
+      - description: Change password request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/server.changePasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.changePasswordResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/server.changePasswordErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/server.changePasswordErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/server.changePasswordErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Change password
       tags:
       - auth
   /api/tags:

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -65,7 +65,11 @@ definitions:
       current_password:
         type: string
       new_password:
+        minLength: 8
         type: string
+    required:
+    - current_password
+    - new_password
     type: object
   server.changePasswordResponse:
     properties:

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -641,12 +641,17 @@
         },
         "server.changePasswordRequest": {
             "type": "object",
+            "required": [
+                "current_password",
+                "new_password"
+            ],
             "properties": {
                 "current_password": {
                     "type": "string"
                 },
                 "new_password": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 8
                 }
             }
         },

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -455,6 +455,63 @@
                 }
             }
         },
+        "/api/auth/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Changes the authenticated user's password.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Change password",
+                "parameters": [
+                    {
+                        "description": "Change password request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.changePasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.changePasswordResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/server.changePasswordErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/server.changePasswordErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/server.changePasswordErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/tags": {
             "get": {
                 "security": [
@@ -570,6 +627,33 @@
                     "type": "integer"
                 },
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.changePasswordErrorResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.changePasswordRequest": {
+            "type": "object",
+            "properties": {
+                "current_password": {
+                    "type": "string"
+                },
+                "new_password": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.changePasswordResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
                     "type": "string"
                 }
             }


### PR DESCRIPTION
## やったこと
- api/internal/auth/password.go — HashPassword 関数を追加（bcrypt, cost 10）
- api/internal/auth/repository/update_password.go — UpdatePassword メソッドを新規作成（UPDATE users SET password_hash, updated_at）
- api/internal/auth/handler/change_password.go — ハンドラ＋ビジネスロジック＋Swagger アノテーションを新規作成
- api/internal/auth/handler/handler.go — authRouter.PUT("/auth/password", ...) ルートを追加
- Swagger JSON/YAML を再生成

## 動作確認
↓この画像はログイン時の動作確認です
<img width="1804" height="948" alt="スクリーンショット 2026-05-13 110121" src="https://github.com/user-attachments/assets/442cc31d-cdc3-4621-b6eb-d29a4f13f651" />

↓この画像は新しいパスワードに変更できた動作確認です

<img width="1819" height="967" alt="スクリーンショット 2026-05-13 110056" src="https://github.com/user-attachments/assets/5593e315-f8ab-420d-a092-80c6122cac31" />




Closes #185