### PR TITLE
いいねresponseにliked_by_meを追加&responseを統一

### DIFF
--- a/api/internal/article/article.go
+++ b/api/internal/article/article.go
@@ -29,6 +29,7 @@ type Article struct {
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 	LikesCount int64
+	LikedByMe  bool
 }
 
 func NormalizeCreateInput(title, content string, tagNames []string) (string, string, []string, error) {

--- a/api/internal/article/handler/get_article.go
+++ b/api/internal/article/handler/get_article.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/Baymax6s/KOBE-Tech/api/internal/auth"
 	"github.com/gin-gonic/gin"
 )
 
@@ -25,6 +26,7 @@ type GetArticleJSONResponse struct {
 	CreatedAt  time.Time        `json:"created_at" binding:"required"`
 	UpdatedAt  time.Time        `json:"updated_at" binding:"required"`
 	LikesCount int64            `json:"likes_count" binding:"required"`
+	LikedByMe  bool             `json:"liked_by_me"`
 } // @name server.getArticleJSONResponse
 
 // getArticleHandler godoc
@@ -46,7 +48,9 @@ func (h *Handler) getArticleHandler(c *gin.Context) {
 		return
 	}
 
-	response, err := h.GetArticle(c.Request.Context(), articleID)
+	userID, _ := auth.OptionalUserID(c)
+
+	response, err := h.GetArticle(c.Request.Context(), articleID, userID)
 	if err != nil {
 		switch {
 		case errors.Is(err, errArticleNotFound):
@@ -62,12 +66,12 @@ func (h *Handler) getArticleHandler(c *gin.Context) {
 
 var errArticleNotFound = errors.New("article not found")
 
-func (h *Handler) GetArticle(ctx context.Context, articleID int64) (GetArticleJSONResponse, error) {
+func (h *Handler) GetArticle(ctx context.Context, articleID int64, userID int64) (GetArticleJSONResponse, error) {
 	if h == nil || h.repo == nil {
 		return GetArticleJSONResponse{}, errors.New("get article handler is not configured")
 	}
 
-	item, err := h.repo.FindArticleByID(ctx, articleID)
+	item, err := h.repo.FindArticleByID(ctx, articleID, userID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return GetArticleJSONResponse{}, errArticleNotFound
@@ -87,5 +91,6 @@ func (h *Handler) GetArticle(ctx context.Context, articleID int64) (GetArticleJS
 		CreatedAt:  item.CreatedAt,
 		UpdatedAt:  item.UpdatedAt,
 		LikesCount: item.LikesCount,
+		LikedByMe:  item.LikedByMe,
 	}, nil
 }

--- a/api/internal/article/handler/get_list_articles.go
+++ b/api/internal/article/handler/get_list_articles.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Baymax6s/KOBE-Tech/api/internal/article"
+	"github.com/Baymax6s/KOBE-Tech/api/internal/auth"
 	"github.com/gin-gonic/gin"
 )
 
@@ -29,6 +30,7 @@ type ArticleListItemJSON struct {
 	CreatedAt  time.Time        `json:"created_at" binding:"required"`
 	UpdatedAt  time.Time        `json:"updated_at" binding:"required"`
 	LikesCount int64            `json:"likes_count" binding:"required"`
+	LikedByMe  bool             `json:"liked_by_me"`
 } // @name server.articleJSONResponse
 
 type ListArticlesJSONResponse struct {
@@ -45,7 +47,9 @@ type ListArticlesJSONResponse struct {
 //	@Failure		500	{object}	ArticleErrorResponse
 //	@Router			/api/articles [get]
 func (h *Handler) listArticlesHandler(c *gin.Context) {
-	response, err := h.ListArticles(c.Request.Context())
+	userID, _ := auth.OptionalUserID(c)
+
+	response, err := h.ListArticles(c.Request.Context(), userID)
 	if err != nil {
 		log.Printf("list articles: %v", err)
 		c.JSON(http.StatusInternalServerError, ArticleErrorResponse{
@@ -57,12 +61,12 @@ func (h *Handler) listArticlesHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-func (h *Handler) ListArticles(ctx context.Context) (ListArticlesJSONResponse, error) {
+func (h *Handler) ListArticles(ctx context.Context, userID int64) (ListArticlesJSONResponse, error) {
 	if h == nil || h.repo == nil {
 		return ListArticlesJSONResponse{}, errors.New("article handler is not configured")
 	}
 
-	articles, err := h.repo.ListArticles(ctx)
+	articles, err := h.repo.ListArticles(ctx, userID)
 	if err != nil {
 		return ListArticlesJSONResponse{}, err
 	}
@@ -85,6 +89,7 @@ func newListArticlesJSONResponse(articles []article.Article) ListArticlesJSONRes
 			CreatedAt:  item.CreatedAt,
 			UpdatedAt:  item.UpdatedAt,
 			LikesCount: item.LikesCount,
+			LikedByMe:  item.LikedByMe,
 		})
 	}
 

--- a/api/internal/article/repository/get_article.go
+++ b/api/internal/article/repository/get_article.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lib/pq"
 )
 
-func (r *Repository) FindArticleByID(ctx context.Context, id int64) (article.Article, error) {
+func (r *Repository) FindArticleByID(ctx context.Context, id int64, userID int64) (article.Article, error) {
 	if r == nil || r.db == nil {
 		return article.Article{}, errors.New("article repository is not configured")
 	}
@@ -24,7 +24,8 @@ func (r *Repository) FindArticleByID(ctx context.Context, id int64) (article.Art
 			a.updated_at,
 			COALESCE((SELECT COUNT(*) FROM likes WHERE article_id = a.id), 0),
 			COALESCE(tag_summary.tag_ids, ARRAY[]::integer[]),
-			COALESCE(tag_summary.tag_names, ARRAY[]::text[])
+			COALESCE(tag_summary.tag_names, ARRAY[]::text[]),
+			EXISTS(SELECT 1 FROM likes WHERE article_id = a.id AND user_id = $2)
 		FROM articles a
 		JOIN users u ON u.id = a.user_id
 		LEFT JOIN LATERAL (
@@ -41,7 +42,7 @@ func (r *Repository) FindArticleByID(ctx context.Context, id int64) (article.Art
 	var item article.Article
 	var tagIDs []int64
 	var tagNames []string
-	err := r.db.QueryRowContext(ctx, query, id).Scan(
+	err := r.db.QueryRowContext(ctx, query, id, userID).Scan(
 		&item.ID,
 		&item.Title,
 		&item.Content,
@@ -52,6 +53,7 @@ func (r *Repository) FindArticleByID(ctx context.Context, id int64) (article.Art
 		&item.LikesCount,
 		pq.Array(&tagIDs),
 		pq.Array(&tagNames),
+		&item.LikedByMe,
 	)
 	if err != nil {
 		return article.Article{}, err

--- a/api/internal/article/repository/get_list_articles.go
+++ b/api/internal/article/repository/get_list_articles.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lib/pq"
 )
 
-func (r *Repository) ListArticles(ctx context.Context) ([]article.Article, error) {
+func (r *Repository) ListArticles(ctx context.Context, userID int64) ([]article.Article, error) {
 	if r == nil || r.db == nil {
 		return nil, errors.New("article repository is not configured")
 	}
@@ -22,7 +22,8 @@ func (r *Repository) ListArticles(ctx context.Context) ([]article.Article, error
 			a.updated_at,
 			COALESCE(l.like_count, 0),
 			COALESCE(tag_summary.tag_ids, ARRAY[]::integer[]),
-			COALESCE(tag_summary.tag_names, ARRAY[]::text[])
+			COALESCE(tag_summary.tag_names, ARRAY[]::text[]),
+			EXISTS(SELECT 1 FROM likes WHERE article_id = a.id AND user_id = $1)
 		FROM articles a
 		LEFT JOIN (
 			SELECT article_id, COUNT(*) AS like_count FROM likes GROUP BY article_id
@@ -39,7 +40,7 @@ func (r *Repository) ListArticles(ctx context.Context) ([]article.Article, error
 		ORDER BY a.created_at DESC, a.id DESC
 	`
 
-	rows, err := r.db.QueryContext(ctx, query)
+	rows, err := r.db.QueryContext(ctx, query, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -60,6 +61,7 @@ func (r *Repository) ListArticles(ctx context.Context) ([]article.Article, error
 			&item.LikesCount,
 			pq.Array(&tagIDs),
 			pq.Array(&tagNames),
+			&item.LikedByMe,
 		); err != nil {
 			return nil, err
 		}

--- a/api/internal/auth/middleware.go
+++ b/api/internal/auth/middleware.go
@@ -56,3 +56,31 @@ func extractBearerToken(header string) (string, bool) {
 	}
 	return parts[1], true
 }
+
+func OptionalUser(v *Validator) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token, ok := extractBearerToken(c.GetHeader("Authorization"))
+		if !ok {
+			c.Next()
+			return
+		}
+
+		userID, err := v.ValidateToken(token)
+		if err != nil {
+			c.Next()
+			return
+		}
+
+		c.Set(userIDContextKey, userID)
+		c.Next()
+	}
+}
+
+func OptionalUserID(c *gin.Context) (int64, bool) {
+	v, exists := c.Get(userIDContextKey)
+	if !exists {
+		return 0, false
+	}
+	userID, ok := v.(int64)
+	return userID, ok
+}

--- a/api/internal/like/handler/create_like.go
+++ b/api/internal/like/handler/create_like.go
@@ -14,6 +14,11 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 } // @name server.likeErrorResponse
 
+type LikeResponse struct {
+	LikesCount int64 `json:"likes_count"`
+	LikedByMe  bool  `json:"liked_by_me"`
+} // @name server.likeResponse
+
 // createLikeHandler godoc
 //
 //	@Summary		Like an article
@@ -22,7 +27,7 @@ type ErrorResponse struct {
 //	@Produce		json
 //	@Param			article_id	path	int	true	"Article ID"
 //
-// @Success		201
+//	@Success		200			{object}	LikeResponse
 //
 //	@Failure		400			{object}	ErrorResponse
 //	@Failure		401			{object}	ErrorResponse
@@ -55,5 +60,11 @@ func (h *Handler) createLikeHandler(c *gin.Context) {
 		return
 	}
 
-	c.Status(http.StatusCreated)
+	count, err := h.repo.CountByArticle(c.Request.Context(), articleID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Message: "failed to count likes"})
+		return
+	}
+
+	c.JSON(http.StatusOK, LikeResponse{LikesCount: count, LikedByMe: true})
 }

--- a/api/internal/like/handler/delete_like.go
+++ b/api/internal/like/handler/delete_like.go
@@ -10,10 +10,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type LikeCountResponse struct {
-	LikesCount int64 `json:"likes_count" binding:"required"`
-} // @name server.likeCountResponse
-
 // deleteLikeHandler godoc
 //
 //	@Summary		Unlike an article
@@ -22,7 +18,7 @@ type LikeCountResponse struct {
 //	@Produce		json
 //	@Param			article_id	path	int	true	"Article ID"
 //
-//	@Success		200			{object}	LikeCountResponse
+//	@Success		200			{object}	LikeResponse
 //
 //	@Failure		400			{object}	ErrorResponse
 //	@Failure		401			{object}	ErrorResponse
@@ -58,5 +54,5 @@ func (h *Handler) deleteLikeHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, LikeCountResponse{LikesCount: count})
+	c.JSON(http.StatusOK, LikeResponse{LikesCount: count, LikedByMe: false})
 }

--- a/api/internal/server/router.go
+++ b/api/internal/server/router.go
@@ -36,7 +36,8 @@ func NewHandler(db *sql.DB, validator *auth.Validator, issuer *auth.Issuer) http
 	api := router.Group("/api")
 
 	authRequired := api.Group("", auth.RequireUser(validator))
-	articleHandler.RegisterRoutes(api, authRequired)
+	optionalAuth := api.Group("", auth.OptionalUser(validator))
+	articleHandler.RegisterRoutes(optionalAuth, authRequired)
 	authHandler.RegisterRoutes(api, authRequired)
 	likeHandler.RegisterRoutes(authRequired)
 	replyHandler.RegisterRoutes(api, authRequired)

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -23,6 +23,8 @@ definitions:
         type: string
       id:
         type: integer
+      liked_by_me:
+        type: boolean
       likes_count:
         type: integer
       tags:
@@ -137,6 +139,8 @@ definitions:
         type: string
       id:
         type: integer
+      liked_by_me:
+        type: boolean
       likes_count:
         type: integer
       tags:
@@ -157,17 +161,18 @@ definitions:
     - title
     - updated_at
     type: object
-  server.likeCountResponse:
-    properties:
-      likes_count:
-        type: integer
-    required:
-    - likes_count
-    type: object
+
   server.likeErrorResponse:
     properties:
       message:
         type: string
+    type: object
+  server.likeResponse:
+    properties:
+      liked_by_me:
+        type: boolean
+      likes_count:
+        type: integer
     type: object
   server.listArticlesResponse:
     properties:
@@ -402,7 +407,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/server.likeCountResponse'
+            $ref: '#/definitions/server.likeResponse'
         "400":
           description: Bad Request
           schema:
@@ -435,8 +440,10 @@ paths:
       produces:
       - application/json
       responses:
-        "201":
-          description: Created
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.likeResponse'
         "400":
           description: Bad Request
           schema:

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -161,7 +161,6 @@ definitions:
     - title
     - updated_at
     type: object
-
   server.likeErrorResponse:
     properties:
       message:

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -825,7 +825,6 @@
                 }
             }
         },
-
         "server.likeErrorResponse": {
             "type": "object",
             "properties": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -165,8 +165,11 @@
                     }
                 ],
                 "responses": {
-                    "201": {
-                        "description": "Created"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.likeResponse"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -227,7 +230,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/server.likeCountResponse"
+                            "$ref": "#/definitions/server.likeResponse"
                         }
                     },
                     "400": {
@@ -633,6 +636,9 @@
                 "id": {
                     "type": "integer"
                 },
+                "liked_by_me": {
+                    "type": "boolean"
+                },
                 "likes_count": {
                     "type": "integer"
                 },
@@ -799,6 +805,9 @@
                 "id": {
                     "type": "integer"
                 },
+                "liked_by_me": {
+                    "type": "boolean"
+                },
                 "likes_count": {
                     "type": "integer"
                 },
@@ -816,22 +825,23 @@
                 }
             }
         },
-        "server.likeCountResponse": {
-            "type": "object",
-            "required": [
-                "likes_count"
-            ],
-            "properties": {
-                "likes_count": {
-                    "type": "integer"
-                }
-            }
-        },
+
         "server.likeErrorResponse": {
             "type": "object",
             "properties": {
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "server.likeResponse": {
+            "type": "object",
+            "properties": {
+                "liked_by_me": {
+                    "type": "boolean"
+                },
+                "likes_count": {
+                    "type": "integer"
                 }
             }
         },

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -24,6 +24,7 @@ export interface ServerArticleJSONResponse {
   created_at: string;
   id: number;
   likes_count: number;
+  liked_by_me: boolean;
   tags: ServerArticleTagJSONResponse[];
   title: string;
   updated_at: string;
@@ -63,6 +64,7 @@ export interface ServerGetArticleJSONResponse {
   created_at: string;
   id: number;
   likes_count: number;
+  liked_by_me: boolean;
   tags: ServerArticleTagJSONResponse[];
   title: string;
   updated_at: string;

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -70,7 +70,8 @@ export interface ServerGetArticleJSONResponse {
   updated_at: string;
 }
 
-export interface ServerLikeCountResponse {
+export interface ServerLikeResponse {
+  liked_by_me: boolean;
   likes_count: number;
 }
 
@@ -391,7 +392,7 @@ export class Api<
      * @secure
      */
     articlesLikeDelete: (articleId: number, params: RequestParams = {}) =>
-      this.request<ServerLikeCountResponse, ServerLikeErrorResponse>({
+      this.request<ServerLikeResponse, ServerLikeErrorResponse>({
         path: `/api/articles/${articleId}/like`,
         method: "DELETE",
         secure: true,
@@ -409,14 +410,16 @@ export class Api<
      * @secure
      */
     articlesLikeCreate: (articleId: number, params: RequestParams = {}) =>
-      this.request<void, ServerLikeErrorResponse>({
+      this.request<ServerLikeResponse, ServerLikeErrorResponse>({
         path: `/api/articles/${articleId}/like`,
         method: "POST",
         secure: true,
+        format: "json",
         ...params,
       }),
 
     /**
+
      * @description 記事に紐づく返信（コメント / 質問 / 回答）を全件取得する。
      *
      * @tags replies

--- a/app/src/features/articles/ArticleCard.vue
+++ b/app/src/features/articles/ArticleCard.vue
@@ -42,7 +42,7 @@ const formattedDate = useDateFormat(
 
       <div class="d-flex align-center">
         <v-icon
-          icon="mdi-heart-outline"
+          :icon="article.liked_by_me ? 'mdi-heart' : 'mdi-heart-outline'"
           size="small"
           color="red"
           class="me-1"

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -38,12 +38,12 @@ const likeArticle = async () => {
   try {
     if (isLiked.value) {
       const response = await api.api.articlesLikeDelete(props.articleId)
-      article.value.liked_by_me = false
+      article.value.liked_by_me = response.data.liked_by_me
       article.value.likes_count = response.data.likes_count
     } else {
-      await api.api.articlesLikeCreate(props.articleId)
-      article.value.liked_by_me = true
-      article.value.likes_count = (article.value.likes_count ?? 0) + 1
+      const response = await api.api.articlesLikeCreate(props.articleId)
+      article.value.liked_by_me = response.data.liked_by_me
+      article.value.likes_count = response.data.likes_count
     }
   } catch (err: unknown) {
     if (axios.isAxiosError(err) && err.response?.status === 409) {

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import axios from 'axios'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useDateFormat } from '@vueuse/core'
 import { api } from '@/api/client'
@@ -19,7 +19,7 @@ const auth = useAuthStore()
 const article = ref<ServerGetArticleJSONResponse | null>(null)
 const loading = ref(false)
 const error = ref<string | null>(null)
-const isLiked = ref(false)
+const isLiked = computed(() => article.value?.liked_by_me ?? false)
 const likeSubmitting = ref(false)
 const likeError = ref<string | null>(null)
 
@@ -38,21 +38,21 @@ const likeArticle = async () => {
   try {
     if (isLiked.value) {
       const response = await api.api.articlesLikeDelete(props.articleId)
-      isLiked.value = false
+      article.value.liked_by_me = false
       article.value.likes_count = response.data.likes_count
     } else {
       await api.api.articlesLikeCreate(props.articleId)
-      isLiked.value = true
+      article.value.liked_by_me = true
       article.value.likes_count = (article.value.likes_count ?? 0) + 1
     }
   } catch (err: unknown) {
     if (axios.isAxiosError(err) && err.response?.status === 409) {
-      isLiked.value = true
+      article.value.liked_by_me = true
       return
     }
 
     if (axios.isAxiosError(err) && err.response?.status === 404) {
-      isLiked.value = false
+      article.value.liked_by_me = false
       return
     }
 
@@ -81,7 +81,6 @@ watch(
     error.value = null
     likeError.value = null
     loading.value = true
-    isLiked.value = false
     likeSubmitting.value = false
 
     try {


### PR DESCRIPTION
## やったこと
- いいね済みかわかるようにget_articlesにresponseを追加
- trueのときはいいね済み falseのときは未いいね
- post deleteエンドポイントのresponseを統一

影響範囲
- つなぎこみの部分も変更しているためフロントとバック両方変更
- liked_by_meを実現するためにミドルウェアを追加

## 動作確認
<img width="1762" height="791" alt="image" src="https://github.com/user-attachments/assets/774c4ebe-b1b6-4ed5-93c8-b1a4262ef20f" />

Closes #160