### PR TITLE
fix: タグチップの選択状態が解除されない不具合を修正

### DIFF
--- a/app/src/features/articles/ArticleCard.vue
+++ b/app/src/features/articles/ArticleCard.vue
@@ -11,12 +11,7 @@ const emit = defineEmits<{
   (e: 'select-tag', tagName: string): void
 }>()
 
-
-
-const isSelected = (tagName: string) =>
-  props.selectedTags.includes(tagName)
-
-
+const isSelected = (tagName: string) => props.selectedTags.includes(tagName)
 
 const formattedDate = useDateFormat(
   () => props.article.created_at ?? '',
@@ -30,10 +25,10 @@ const formattedDate = useDateFormat(
       {{ article.title }}
     </v-card-title>
 
-  <v-card-text v-if="article.tags?.length" class="py-0 px-4">
-    <div class="d-flex ga-1 flex-wrap">
-      <v-chip
-        v-for="tag in article.tags"
+    <v-card-text v-if="article.tags?.length" class="py-0 px-4">
+      <div class="d-flex ga-1 flex-wrap">
+        <v-chip
+          v-for="tag in article.tags"
           :key="tag.id"
           size="x-small"
           :variant="isSelected(tag.name) ? 'flat' : 'outlined'"
@@ -44,7 +39,6 @@ const formattedDate = useDateFormat(
         </v-chip>
       </div>
     </v-card-text>
-
 
     <v-card-subtitle
       class="text-sm text-gray-500 d-flex align-center justify-space-between mt-2"

--- a/app/src/features/articles/ArticleCard.vue
+++ b/app/src/features/articles/ArticleCard.vue
@@ -2,11 +2,21 @@
 import { useDateFormat } from '@vueuse/core'
 import type { ServerArticleJSONResponse } from '@/api/generated/apiSchema'
 
-const props = defineProps<{ article: ServerArticleJSONResponse }>()
+const props = defineProps<{
+  article: ServerArticleJSONResponse
+  selectedTags: string[]
+}>()
 
 const emit = defineEmits<{
   (e: 'select-tag', tagName: string): void
 }>()
+
+
+
+const isSelected = (tagName: string) =>
+  props.selectedTags.includes(tagName)
+
+
 
 const formattedDate = useDateFormat(
   () => props.article.created_at ?? '',
@@ -20,20 +30,21 @@ const formattedDate = useDateFormat(
       {{ article.title }}
     </v-card-title>
 
-    <v-card-text v-if="article.tags?.length" class="py-0 px-4">
-      <v-chip-group>
-        <v-chip
-          v-for="tag in article.tags"
+  <v-card-text v-if="article.tags?.length" class="py-0 px-4">
+    <div class="d-flex ga-1 flex-wrap">
+      <v-chip
+        v-for="tag in article.tags"
           :key="tag.id"
           size="x-small"
-          variant="outlined"
-          color="primary"
+          :variant="isSelected(tag.name) ? 'flat' : 'outlined'"
+          :color="isSelected(tag.name) ? 'primary' : undefined"
           @click.stop.prevent="emit('select-tag', tag.name)"
         >
           {{ tag.name }}
         </v-chip>
-      </v-chip-group>
+      </div>
     </v-card-text>
+
 
     <v-card-subtitle
       class="text-sm text-gray-500 d-flex align-center justify-space-between mt-2"

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -148,12 +148,15 @@ onMounted(async () => {
         </v-alert>
 
         <div v-else class="d-flex flex-column ga-4">
+          
           <ArticleCard
             v-for="article in filteredArticles"
             :key="article.id"
             :article="article"
+            :selected-tags="selectedTags"
             @select-tag="toggleTag"
           />
+
 
           <v-alert
             v-if="filteredArticles.length === 0"

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -148,7 +148,6 @@ onMounted(async () => {
         </v-alert>
 
         <div v-else class="d-flex flex-column ga-4">
-          
           <ArticleCard
             v-for="article in filteredArticles"
             :key="article.id"
@@ -156,7 +155,6 @@ onMounted(async () => {
             :selected-tags="selectedTags"
             @select-tag="toggleTag"
           />
-
 
           <v-alert
             v-if="filteredArticles.length === 0"


### PR DESCRIPTION
## やったこと
- タグチップの選択状態が解除されない不具合を修正
- v-chip-groupを削除し状態管理をselectedTagsに統一
- selectedTagsをArticleCardにpropsとして渡してUIと同期
- チップのスタイルを選択状態に応じて動的に変更


## 動作確認
<img width="1915" height="1071" alt="スクリーンショット 2026-05-14 105015" src="https://github.com/user-attachments/assets/c5d70253-e0c7-4fbb-83f0-23e5fff2a7e3" />
<img width="1919" height="999" alt="スクリーンショット 2026-05-14 105025" src="https://github.com/user-attachments/assets/9e3e48dc-adb1-4afa-b3c4-ed12b9c37d7f" />
<img width="1919" height="1004" alt="スクリーンショット 2026-05-14 105034" src="https://github.com/user-attachments/assets/d9cf4a8e-c4b0-4ca5-b1a6-3c4552316229" />
