### PR TITLE
swaggerの分類をinternalフォルダネームに統一

### DIFF
--- a/api/internal/article/handler/create_article.go
+++ b/api/internal/article/handler/create_article.go
@@ -31,7 +31,7 @@ type CreateArticleJSONResponse struct {
 //
 //	@Summary		Create article
 //	@Description	Create article API.
-//	@Tags			articles
+//	@Tags			article
 //	@Accept			json
 //	@Produce		json
 //	@Param			request	body		createArticleRequest	true	"Create article request"

--- a/api/internal/article/handler/get_article.go
+++ b/api/internal/article/handler/get_article.go
@@ -33,7 +33,7 @@ type GetArticleJSONResponse struct {
 //
 //	@Summary		Get article
 //	@Description	Get article detail API.
-//	@Tags			articles
+//	@Tags			article
 //	@Produce		json
 //	@Param			article_id	path		int	true	"Article ID"
 //	@Success		200			{object}	GetArticleJSONResponse

--- a/api/internal/article/handler/get_list_articles.go
+++ b/api/internal/article/handler/get_list_articles.go
@@ -41,7 +41,7 @@ type ListArticlesJSONResponse struct {
 //
 //	@Summary		List articles
 //	@Description	Get article list API.
-//	@Tags			articles
+//	@Tags			article
 //	@Produce		json
 //	@Success		200	{object}	ListArticlesJSONResponse
 //	@Failure		500	{object}	ArticleErrorResponse

--- a/api/internal/article/handler/get_list_tags.go
+++ b/api/internal/article/handler/get_list_tags.go
@@ -27,7 +27,7 @@ type ListTagsJSONResponse struct {
 //
 //	@Summary		List tags
 //	@Description	Get tag candidates for creating articles.
-//	@Tags			tags
+//	@Tags			article
 //	@Produce		json
 //	@Success		200	{object}	ListTagsJSONResponse
 //	@Failure		401	{object}	TagsErrorResponse

--- a/api/internal/like/handler/create_like.go
+++ b/api/internal/like/handler/create_like.go
@@ -23,7 +23,7 @@ type LikeResponse struct {
 //
 //	@Summary		Like an article
 //	@Description	Like an article API.
-//	@Tags			articles
+//	@Tags			like
 //	@Produce		json
 //	@Param			article_id	path	int	true	"Article ID"
 //

--- a/api/internal/like/handler/delete_like.go
+++ b/api/internal/like/handler/delete_like.go
@@ -14,7 +14,7 @@ import (
 //
 //	@Summary		Unlike an article
 //	@Description	Unlike an article API.
-//	@Tags			articles
+//	@Tags			like
 //	@Produce		json
 //	@Param			article_id	path	int	true	"Article ID"
 //

--- a/api/internal/reply/handler/create_reply.go
+++ b/api/internal/reply/handler/create_reply.go
@@ -22,7 +22,7 @@ type createReplyRequest struct {
 //
 //	@Summary		Create a reply on an article
 //	@Description	記事 / 既存返信への返信を投稿する。kind は comment / question / answer のいずれか。ルート投稿は comment か question、コメント配下は comment、質問・回答配下は answer のみ受け付ける。
-//	@Tags			replies
+//	@Tags			reply
 //	@Accept			json
 //	@Produce		json
 //	@Param			article_id	path		int					true	"Article ID"

--- a/api/internal/reply/handler/get_list_replies.go
+++ b/api/internal/reply/handler/get_list_replies.go
@@ -36,7 +36,7 @@ type ErrorResponse struct {
 //
 //	@Summary		List replies of an article
 //	@Description	記事に紐づく返信（コメント / 質問 / 回答）を全件取得する。
-//	@Tags			replies
+//	@Tags			reply
 //	@Produce		json
 //	@Param			article_id	path		int	true	"Article ID"
 //	@Success		200			{object}	ListRepliesJSONResponse

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -336,7 +336,7 @@ paths:
             $ref: '#/definitions/server.articleErrorResponse'
       summary: List articles
       tags:
-      - articles
+      - article
     post:
       consumes:
       - application/json
@@ -371,7 +371,7 @@ paths:
       - BearerAuth: []
       summary: Create article
       tags:
-      - articles
+      - article
   /api/articles/{article_id}:
     get:
       description: Get article detail API.
@@ -402,7 +402,7 @@ paths:
             $ref: '#/definitions/server.articleErrorResponse'
       summary: Get article
       tags:
-      - articles
+      - article
   /api/articles/{article_id}/like:
     delete:
       description: Unlike an article API.
@@ -439,7 +439,7 @@ paths:
       - BearerAuth: []
       summary: Unlike an article
       tags:
-      - articles
+      - like
     post:
       description: Like an article API.
       parameters:
@@ -479,7 +479,7 @@ paths:
       - BearerAuth: []
       summary: Like an article
       tags:
-      - articles
+      - like
   /api/articles/{article_id}/replies:
     get:
       description: 記事に紐づく返信（コメント / 質問 / 回答）を全件取得する。
@@ -506,7 +506,7 @@ paths:
             $ref: '#/definitions/server.replyErrorResponse'
       summary: List replies of an article
       tags:
-      - replies
+      - reply
     post:
       consumes:
       - application/json
@@ -551,7 +551,7 @@ paths:
       - BearerAuth: []
       summary: Create a reply on an article
       tags:
-      - replies
+      - reply
   /api/auth/login:
     post:
       consumes:
@@ -727,7 +727,7 @@ paths:
       - BearerAuth: []
       summary: List tags
       tags:
-      - tags
+      - article
 schemes:
 - http
 securityDefinitions:

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -19,7 +19,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "articles"
+                    "article"
                 ],
                 "summary": "List articles",
                 "responses": {
@@ -51,7 +51,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "articles"
+                    "article"
                 ],
                 "summary": "Create article",
                 "parameters": [
@@ -100,7 +100,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "articles"
+                    "article"
                 ],
                 "summary": "Get article",
                 "parameters": [
@@ -152,7 +152,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "articles"
+                    "like"
                 ],
                 "summary": "Like an article",
                 "parameters": [
@@ -214,7 +214,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "articles"
+                    "like"
                 ],
                 "summary": "Unlike an article",
                 "parameters": [
@@ -267,7 +267,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "replies"
+                    "reply"
                 ],
                 "summary": "List replies of an article",
                 "parameters": [
@@ -314,7 +314,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "replies"
+                    "reply"
                 ],
                 "summary": "Create a reply on an article",
                 "parameters": [
@@ -621,7 +621,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "tags"
+                    "article"
                 ],
                 "summary": "List tags",
                 "responses": {

--- a/app/public/mockServiceWorker.js
+++ b/app/public/mockServiceWorker.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /* tslint:disable */
 
 /**

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -23,8 +23,8 @@ export interface ServerArticleJSONResponse {
   content: string;
   created_at: string;
   id: number;
+  liked_by_me?: boolean;
   likes_count: number;
-  liked_by_me: boolean;
   tags: ServerArticleTagJSONResponse[];
   title: string;
   updated_at: string;
@@ -77,21 +77,22 @@ export interface ServerGetArticleJSONResponse {
   content: string;
   created_at: string;
   id: number;
+  liked_by_me?: boolean;
   likes_count: number;
-  liked_by_me: boolean;
   tags: ServerArticleTagJSONResponse[];
   title: string;
   updated_at: string;
 }
 
-export interface ServerLikeResponse {
-  liked_by_me: boolean;
-  likes_count: number;
-}
-
 export interface ServerLikeErrorResponse {
   message?: string;
 }
+
+export interface ServerLikeResponse {
+  liked_by_me?: boolean;
+  likes_count?: number;
+}
+
 export interface ServerListArticlesResponse {
   articles?: ServerArticleJSONResponse[];
 }
@@ -363,7 +364,7 @@ export class Api<
     /**
      * @description Get article list API.
      *
-     * @tags articles
+     * @tags article
      * @name ArticlesList
      * @summary List articles
      * @request GET:/api/articles
@@ -379,7 +380,7 @@ export class Api<
     /**
      * @description Create article API.
      *
-     * @tags articles
+     * @tags article
      * @name ArticlesCreate
      * @summary Create article
      * @request POST:/api/articles
@@ -402,7 +403,7 @@ export class Api<
     /**
      * @description Get article detail API.
      *
-     * @tags articles
+     * @tags article
      * @name ArticlesDetail
      * @summary Get article
      * @request GET:/api/articles/{article_id}
@@ -418,7 +419,7 @@ export class Api<
     /**
      * @description Unlike an article API.
      *
-     * @tags articles
+     * @tags like
      * @name ArticlesLikeDelete
      * @summary Unlike an article
      * @request DELETE:/api/articles/{article_id}/like
@@ -436,7 +437,7 @@ export class Api<
     /**
      * @description Like an article API.
      *
-     * @tags articles
+     * @tags like
      * @name ArticlesLikeCreate
      * @summary Like an article
      * @request POST:/api/articles/{article_id}/like
@@ -452,10 +453,9 @@ export class Api<
       }),
 
     /**
-
      * @description 記事に紐づく返信（コメント / 質問 / 回答）を全件取得する。
      *
-     * @tags replies
+     * @tags reply
      * @name ArticlesRepliesList
      * @summary List replies of an article
      * @request GET:/api/articles/{article_id}/replies
@@ -471,7 +471,7 @@ export class Api<
     /**
      * @description 記事 / 既存返信への返信を投稿する。kind は comment / question / answer のいずれか。ルート投稿は comment か question、コメント配下は comment、質問・回答配下は answer のみ受け付ける。
      *
-     * @tags replies
+     * @tags reply
      * @name ArticlesRepliesCreate
      * @summary Create a reply on an article
      * @request POST:/api/articles/{article_id}/replies
@@ -601,7 +601,7 @@ export class Api<
     /**
      * @description Get tag candidates for creating articles.
      *
-     * @tags tags
+     * @tags article
      * @name TagsList
      * @summary List tags
      * @request GET:/api/tags

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -38,12 +38,12 @@ const likeArticle = async () => {
   try {
     if (isLiked.value) {
       const response = await api.api.articlesLikeDelete(props.articleId)
-      article.value.liked_by_me = response.data.liked_by_me
-      article.value.likes_count = response.data.likes_count
+      article.value.liked_by_me = response.data.liked_by_me ?? article.value.liked_by_me
+      article.value.likes_count = response.data.likes_count ?? article.value.likes_count
     } else {
       const response = await api.api.articlesLikeCreate(props.articleId)
-      article.value.liked_by_me = response.data.liked_by_me
-      article.value.likes_count = response.data.likes_count
+      article.value.liked_by_me = response.data.liked_by_me ?? article.value.liked_by_me
+      article.value.likes_count = response.data.likes_count ?? article.value.likes_count
     }
   } catch (err: unknown) {
     if (axios.isAxiosError(err) && err.response?.status === 409) {

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -38,12 +38,16 @@ const likeArticle = async () => {
   try {
     if (isLiked.value) {
       const response = await api.api.articlesLikeDelete(props.articleId)
-      article.value.liked_by_me = response.data.liked_by_me ?? article.value.liked_by_me
-      article.value.likes_count = response.data.likes_count ?? article.value.likes_count
+      article.value.liked_by_me =
+        response.data.liked_by_me ?? article.value.liked_by_me
+      article.value.likes_count =
+        response.data.likes_count ?? article.value.likes_count
     } else {
       const response = await api.api.articlesLikeCreate(props.articleId)
-      article.value.liked_by_me = response.data.liked_by_me ?? article.value.liked_by_me
-      article.value.likes_count = response.data.likes_count ?? article.value.likes_count
+      article.value.liked_by_me =
+        response.data.liked_by_me ?? article.value.liked_by_me
+      article.value.likes_count =
+        response.data.likes_count ?? article.value.likes_count
     }
   } catch (err: unknown) {
     if (axios.isAxiosError(err) && err.response?.status === 409) {


### PR DESCRIPTION
## やったこと
- swaggerの分類を現在のフォルダネームに統一

## 動作確認
internal
 ┣ article
 ┣ auth
 ┣ like
 ┣ profile
 ┣ reply
<img width="1188" height="831" alt="image" src="https://github.com/user-attachments/assets/494827ba-4bc7-4804-8d29-bb509dbf95be" />

Closes #212