### PR TITLE
Revert: ベストアンサーUI（バックエンド未実装のため）

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -1,19 +1,10 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
 import Header from './components/Header.vue'
-import { useAuthStore } from './stores/auth'
 
 const route = useRoute()
 const showHeader = computed(() => route.meta?.hideHeader !== true)
-const auth = useAuthStore()
-
-// リロード時にトークンはあるがuserIdがnullのため、全ページ共通でユーザー情報を復元する
-onMounted(() => {
-  if (auth.isAuthenticated) {
-    auth.fetchCurrentUser()
-  }
-})
 </script>
 
 <template>

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -149,7 +149,6 @@ export interface ServerReplyJSONResponse {
   body: string;
   created_at: string;
   id: number;
-  is_best: boolean;
   kind: "comment" | "question" | "answer";
   parent_id?: number;
   updated_at: string;
@@ -489,50 +488,6 @@ export class Api<
         body: request,
         secure: true,
         type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Mark a reply as best answer.
-     *
-     * @tags replies
-     * @name ArticlesRepliesBestCreate
-     * @summary Mark reply as best answer
-     * @request PATCH:/api/articles/{article_id}/replies/{reply_id}/best
-     * @secure
-     */
-    articlesRepliesBestCreate: (
-      articleId: number,
-      replyId: number,
-      params: RequestParams = {},
-    ) =>
-      this.request<ServerReplyJSONResponse, ServerReplyErrorResponse>({
-        path: `/api/articles/${articleId}/replies/${replyId}/best`,
-        method: "PATCH",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Unmark a reply as best answer.
-     *
-     * @tags replies
-     * @name ArticlesRepliesBestDelete
-     * @summary Unmark reply as best answer
-     * @request DELETE:/api/articles/{article_id}/replies/{reply_id}/best
-     * @secure
-     */
-    articlesRepliesBestDelete: (
-      articleId: number,
-      replyId: number,
-      params: RequestParams = {},
-    ) =>
-      this.request<ServerReplyJSONResponse, ServerReplyErrorResponse>({
-        path: `/api/articles/${articleId}/replies/${replyId}/best`,
-        method: "DELETE",
-        secure: true,
         format: "json",
         ...params,
       }),

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -166,10 +166,7 @@ watch(
             </v-card>
 
             <div class="mt-10">
-              <ReplySection
-                :article-id="article.id"
-                :article-author-id="article.author.id"
-              />
+              <ReplySection :article-id="article.id" />
             </div>
           </template>
         </v-col>

--- a/app/src/features/replies/ReplyItem.vue
+++ b/app/src/features/replies/ReplyItem.vue
@@ -11,12 +11,10 @@ const props = defineProps<{
   reply: ServerReplyJSONResponse
   canReply: boolean
   replying: boolean
-  isQuestionAuthor: boolean
 }>()
 
 defineEmits<{
   (e: 'toggle-reply'): void
-  (e: 'toggle-best'): void
 }>()
 
 const kindBadge = computed(() => {
@@ -65,28 +63,10 @@ const formattedDate = useTimeAgo(() => props.reply.created_at, {
 </script>
 
 <template>
-  <v-card
-    flat
-    rounded="lg"
-    :class="[
-      'pa-4',
-      reply.is_best ? 'bg-amber-lighten-5' : 'bg-grey-lighten-5',
-    ]"
-    :style="reply.is_best ? { borderLeft: '4px solid #FFC107' } : {}"
-  >
+  <v-card flat rounded="lg" class="pa-4 bg-grey-lighten-5">
     <div class="d-flex align-center ga-2 mb-2">
       <v-chip :color="kindBadge.color" size="small" variant="tonal" label>
         {{ kindBadge.label }}
-      </v-chip>
-      <v-chip
-        v-if="reply.is_best"
-        color="amber"
-        size="small"
-        variant="flat"
-        label
-      >
-        <v-icon start icon="mdi-star" size="x-small" />
-        ベストアンサー
       </v-chip>
       <span class="text-body-2 font-weight-medium">
         {{ reply.user_name }}
@@ -100,9 +80,8 @@ const formattedDate = useTimeAgo(() => props.reply.created_at, {
       {{ reply.body }}
     </div>
 
-    <div class="d-flex align-center ga-2">
+    <div v-if="canReply" class="d-flex">
       <v-btn
-        v-if="canReply"
         variant="text"
         size="small"
         color="primary"
@@ -110,16 +89,6 @@ const formattedDate = useTimeAgo(() => props.reply.created_at, {
         @click="$emit('toggle-reply')"
       >
         {{ replying ? 'キャンセル' : replyActionLabel }}
-      </v-btn>
-      <v-btn
-        v-if="isQuestionAuthor && reply.kind === 'answer'"
-        variant="text"
-        size="small"
-        :color="reply.is_best ? 'amber' : 'grey'"
-        prepend-icon="mdi-star"
-        @click="$emit('toggle-best')"
-      >
-        {{ reply.is_best ? 'ベストアンサーを解除' : 'ベストアンサーに選択' }}
       </v-btn>
     </div>
   </v-card>

--- a/app/src/features/replies/ReplySection.vue
+++ b/app/src/features/replies/ReplySection.vue
@@ -12,10 +12,9 @@ defineOptions({
   name: 'ReplySection',
 })
 
-const props = defineProps<{ articleId: number; articleAuthorId: number }>()
+const props = defineProps<{ articleId: number }>()
 
-const authStore = useAuthStore()
-const { isAuthenticated } = storeToRefs(authStore)
+const { isAuthenticated } = storeToRefs(useAuthStore())
 const route = useRoute()
 const loginRedirect = computed(
   () => `/login?redirect=${encodeURIComponent(route.fullPath)}`,
@@ -24,15 +23,6 @@ const loginRedirect = computed(
 const replies = ref<ServerReplyJSONResponse[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
-
-const isQuestionAuthor = computed(() => {
-  return (
-    authStore.userId !== null &&
-    replies.value.some(
-      (r) => r.kind === 'question' && r.user_id === authStore.userId,
-    )
-  )
-})
 
 const childrenByParent = computed(() => {
   const map = new Map<number, ServerReplyJSONResponse[]>()
@@ -95,31 +85,6 @@ const fetchReplies = async (id: number) => {
 
 const handleSubmitted = (newReply: ServerReplyJSONResponse) => {
   replies.value = [...replies.value, newReply]
-}
-
-const toggleBestSubmitting = ref(false)
-
-const handleToggleBest = async (replyId: number) => {
-  if (toggleBestSubmitting.value) return
-  toggleBestSubmitting.value = true
-  try {
-    const reply = replies.value.find((r) => r.id === replyId)
-    if (!reply) return
-    if (reply.is_best) {
-      await api.api.articlesRepliesBestDelete(props.articleId, replyId, {
-        skipGlobalErrorHandler: true,
-      })
-    } else {
-      await api.api.articlesRepliesBestCreate(props.articleId, replyId, {
-        skipGlobalErrorHandler: true,
-      })
-    }
-    await fetchReplies(props.articleId)
-  } catch {
-    error.value = 'ベストアンサーの更新に失敗しました'
-  } finally {
-    toggleBestSubmitting.value = false
-  }
 }
 
 watch(
@@ -190,9 +155,7 @@ watch(
         :descendant-count-by-parent="descendantCountByParent"
         :depth="0"
         :article-id="articleId"
-        :is-question-author="isQuestionAuthor"
         @submitted="handleSubmitted"
-        @toggle-best="handleToggleBest"
       />
     </div>
   </section>

--- a/app/src/features/replies/ReplyThread.vue
+++ b/app/src/features/replies/ReplyThread.vue
@@ -16,12 +16,10 @@ const props = defineProps<{
   descendantCountByParent: Map<number, number>
   depth: number
   articleId: number
-  isQuestionAuthor: boolean
 }>()
 
 const emit = defineEmits<{
   (e: 'submitted', reply: ServerReplyJSONResponse): void
-  (e: 'toggle-best', replyId: number): void
 }>()
 
 const { isAuthenticated } = storeToRefs(useAuthStore())
@@ -47,10 +45,6 @@ const handleSubmitted = (newReply: ServerReplyJSONResponse) => {
   showReplyForm.value = false
   expanded.value = true
 }
-
-const handleToggleBest = (replyId: number) => {
-  emit('toggle-best', replyId)
-}
 </script>
 
 <template>
@@ -59,9 +53,7 @@ const handleToggleBest = (replyId: number) => {
       :reply="reply"
       :can-reply="isAuthenticated"
       :replying="showReplyForm"
-      :is-question-author="isQuestionAuthor"
       @toggle-reply="toggleReplyForm"
-      @toggle-best="handleToggleBest(reply.id)"
     />
 
     <div v-if="showReplyForm" class="ml-8">
@@ -84,9 +76,7 @@ const handleToggleBest = (replyId: number) => {
           :descendant-count-by-parent="descendantCountByParent"
           :depth="depth + 1"
           :article-id="articleId"
-          :is-question-author="isQuestionAuthor"
           @submitted="emit('submitted', $event)"
-          @toggle-best="emit('toggle-best', $event)"
         />
       </div>
       <v-btn

--- a/app/src/stores/auth.ts
+++ b/app/src/stores/auth.ts
@@ -1,11 +1,9 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import axios from 'axios'
 import { api, AUTH_TOKEN_STORAGE_KEY } from '@/api/client'
 
 export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(localStorage.getItem(AUTH_TOKEN_STORAGE_KEY))
-  const userId = ref<number | null>(null)
 
   const isAuthenticated = computed(() => token.value !== null)
 
@@ -16,22 +14,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   const clearToken = () => {
     token.value = null
-    userId.value = null
     localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY)
-  }
-
-  const fetchCurrentUser = async () => {
-    if (!token.value) return
-    try {
-      const { data } = await api.api.authMeList({
-        skipGlobalErrorHandler: true,
-      })
-      userId.value = data.id ?? null
-    } catch (err) {
-      if (axios.isAxiosError(err) && err.response?.status === 401) {
-        clearToken()
-      }
-    }
   }
 
   const login = async (name: string, password: string) => {
@@ -40,15 +23,12 @@ export const useAuthStore = defineStore('auth', () => {
       throw new Error('トークンが返却されませんでした')
     }
     setToken(data.token)
-    await fetchCurrentUser()
   }
 
   return {
     token,
-    userId,
     isAuthenticated,
     login,
     clearToken,
-    fetchCurrentUser,
   }
 })


### PR DESCRIPTION
## 背景
PR #210 はバックエンド未実装の状態で `apiSchema.ts` を手書きで拡張してマージされていた。
別ブランチで `npm run generate:api` を走らせたところ手書き分が消失し、Vue 側で型エラーが発生する状態になっている。

PR #210 本文の注記:
> バックエンド実装後、`npm run generate:api`で再生成し、手動追加分を削除してください

本 PR はその「手動追加分の削除」を、UIごと一旦巻き戻す形で実施する。

## 復活方法
バックエンド実装完了後、本 PR のマージコミットに対して `git revert` を実行すれば UI が戻る（その際は backend handler + swagger 再生成 + apiSchema 再生成をセットで含めること）。