### PR TITLE
feat: 記事一覧のタグ絞り込みを URL クエリ駆動 / case-insensitive に

### DIFF
--- a/api/internal/article/article.go
+++ b/api/internal/article/article.go
@@ -52,18 +52,21 @@ func NormalizeTagNames(tagNames []string) ([]string, error) {
 	seen := make(map[string]struct{}, len(tagNames))
 
 	for _, tagName := range tagNames {
-		normalizedTagName := strings.ToLower(strings.TrimSpace(tagName))
+		normalizedTagName := strings.TrimSpace(tagName)
 		if normalizedTagName == "" {
 			return nil, ErrInvalidTagName
 		}
 		if utf8.RuneCountInString(normalizedTagName) > maxTagNameLength {
 			return nil, ErrInvalidTagName
 		}
-		if _, ok := seen[normalizedTagName]; ok {
+		// 表示用に原文ケースを残す。重複判定は DB の UNIQUE(LOWER(name)) と揃えて
+		// 大文字小文字を区別しない。
+		dedupKey := strings.ToLower(normalizedTagName)
+		if _, ok := seen[dedupKey]; ok {
 			continue
 		}
 
-		seen[normalizedTagName] = struct{}{}
+		seen[dedupKey] = struct{}{}
 		normalizedTagNames = append(normalizedTagNames, normalizedTagName)
 	}
 

--- a/api/internal/article/handler/get_list_articles.go
+++ b/api/internal/article/handler/get_list_articles.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Baymax6s/KOBE-Tech/api/internal/article"
@@ -40,16 +41,26 @@ type ListArticlesJSONResponse struct {
 // listArticlesHandler godoc
 //
 //	@Summary		List articles
-//	@Description	Get article list API.
+//	@Description	Get article list API. Supports filtering by tag name (AND).
 //	@Tags			article
 //	@Produce		json
+//	@Param			tag	query		[]string	false	"Filter by tag name (multiple = AND)"	collectionFormat(multi)
 //	@Success		200	{object}	ListArticlesJSONResponse
+//	@Failure		400	{object}	ArticleErrorResponse
 //	@Failure		500	{object}	ArticleErrorResponse
 //	@Router			/api/articles [get]
 func (h *Handler) listArticlesHandler(c *gin.Context) {
 	userID, _ := auth.OptionalUserID(c)
 
-	response, err := h.ListArticles(c.Request.Context(), userID)
+	tagNames, err := normalizeFilterTagNames(c.QueryArray("tag"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ArticleErrorResponse{
+			Message: "invalid tag query parameter",
+		})
+		return
+	}
+
+	response, err := h.ListArticles(c.Request.Context(), userID, tagNames)
 	if err != nil {
 		log.Printf("list articles: %v", err)
 		c.JSON(http.StatusInternalServerError, ArticleErrorResponse{
@@ -61,17 +72,41 @@ func (h *Handler) listArticlesHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-func (h *Handler) ListArticles(ctx context.Context, userID int64) (ListArticlesJSONResponse, error) {
+func (h *Handler) ListArticles(ctx context.Context, userID int64, tagNames []string) (ListArticlesJSONResponse, error) {
 	if h == nil || h.repo == nil {
 		return ListArticlesJSONResponse{}, errors.New("article handler is not configured")
 	}
 
-	articles, err := h.repo.ListArticles(ctx, userID)
+	articles, err := h.repo.ListArticles(ctx, userID, tagNames)
 	if err != nil {
 		return ListArticlesJSONResponse{}, err
 	}
 
 	return newListArticlesJSONResponse(articles), nil
+}
+
+// normalizeFilterTagNames は ?tag=... のクエリパラメータを SQL の LOWER(t.name) 比較に揃える。
+// trim / 長さ / 重複の検証は NormalizeTagNames に任せ、最後に lowercase だけ施す。
+// 空文字は「絞り込み無し」の意味なので、エラーにせず除外してから渡す。
+func normalizeFilterTagNames(raw []string) ([]string, error) {
+	filtered := make([]string, 0, len(raw))
+	for _, t := range raw {
+		if strings.TrimSpace(t) == "" {
+			continue
+		}
+		filtered = append(filtered, t)
+	}
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+	normalized, err := article.NormalizeTagNames(filtered)
+	if err != nil {
+		return nil, err
+	}
+	for i, n := range normalized {
+		normalized[i] = strings.ToLower(n)
+	}
+	return normalized, nil
 }
 
 func newListArticlesJSONResponse(articles []article.Article) ListArticlesJSONResponse {

--- a/api/internal/article/handler/get_list_tags.go
+++ b/api/internal/article/handler/get_list_tags.go
@@ -26,13 +26,11 @@ type ListTagsJSONResponse struct {
 // listTagsHandler godoc
 //
 //	@Summary		List tags
-//	@Description	Get tag candidates for creating articles.
+//	@Description	Get all tag names. Used for tag candidates on the article list / create screens. No auth required.
 //	@Tags			article
 //	@Produce		json
 //	@Success		200	{object}	ListTagsJSONResponse
-//	@Failure		401	{object}	TagsErrorResponse
 //	@Failure		500	{object}	TagsErrorResponse
-//	@Security		BearerAuth
 //	@Router			/api/tags [get]
 func (h *Handler) listTagsHandler(c *gin.Context) {
 	response, err := h.ListTags(c.Request.Context())

--- a/api/internal/article/handler/handler.go
+++ b/api/internal/article/handler/handler.go
@@ -16,6 +16,6 @@ func NewHandler(repo *repository.Repository) *Handler {
 func (h *Handler) RegisterRoutes(router gin.IRouter, authRouter gin.IRouter) {
 	router.GET("/articles", h.listArticlesHandler)
 	router.GET("/articles/:article_id", h.getArticleHandler)
+	router.GET("/tags", h.listTagsHandler)
 	authRouter.POST("/articles", h.createArticleHandler)
-	authRouter.GET("/tags", h.listTagsHandler)
 }

--- a/api/internal/article/repository/create_article.go
+++ b/api/internal/article/repository/create_article.go
@@ -61,10 +61,12 @@ func (r *Repository) CreateArticle(ctx context.Context, title, content string, u
 }
 
 func upsertTag(ctx context.Context, tx *sql.Tx, name string) (article.Tag, error) {
+	// "Vue" と "vue" を同一タグとして扱うため、検索も衝突判定も LOWER(name) で行う。
+	// 既存行が見つかった場合は最初に登録された原文ケース（tag.Name）をそのまま返す。
 	const selectQuery = `
 		SELECT id, name
 		FROM tags
-		WHERE name = $1
+		WHERE LOWER(name) = LOWER($1)
 	`
 
 	var tag article.Tag
@@ -79,7 +81,7 @@ func upsertTag(ctx context.Context, tx *sql.Tx, name string) (article.Tag, error
 	const insertQuery = `
 		INSERT INTO tags (name, created_at, updated_at)
 		VALUES ($1, NOW(), NOW())
-		ON CONFLICT (name) DO NOTHING
+		ON CONFLICT (LOWER(name)) DO NOTHING
 		RETURNING id, name
 	`
 

--- a/api/internal/article/repository/get_list_articles.go
+++ b/api/internal/article/repository/get_list_articles.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lib/pq"
 )
 
-func (r *Repository) ListArticles(ctx context.Context, userID int64) ([]article.Article, error) {
+func (r *Repository) ListArticles(ctx context.Context, userID int64, tagNames []string) ([]article.Article, error) {
 	if r == nil || r.db == nil {
 		return nil, errors.New("article repository is not configured")
 	}
@@ -37,10 +37,28 @@ func (r *Repository) ListArticles(ctx context.Context, userID int64) ([]article.
 			JOIN tags t ON t.id = article_tag.tag_id
 			GROUP BY article_tag.article_id
 		) tag_summary ON tag_summary.article_id = a.id
-		ORDER BY a.created_at DESC, a.id DESC
 	`
 
-	rows, err := r.db.QueryContext(ctx, query, userID)
+	args := []any{userID}
+	if len(tagNames) > 0 {
+		// 指定された tag をすべて持つ記事のみに絞る（AND セマンティクス）。
+		// 大文字小文字は区別しないので比較は LOWER(name) で行い、tagNames も lowercase 済みを渡す。
+		// HAVING COUNT(DISTINCT LOWER(t.name)) = $3 で「一致した tag の種類数 == 要求された tag 数」を担保。
+		query += `
+		WHERE a.id IN (
+			SELECT article_tag.article_id
+			FROM article_tags article_tag
+			JOIN tags t ON t.id = article_tag.tag_id
+			WHERE LOWER(t.name) = ANY($2::text[])
+			GROUP BY article_tag.article_id
+			HAVING COUNT(DISTINCT LOWER(t.name)) = $3
+		)
+		`
+		args = append(args, pq.Array(tagNames), len(tagNames))
+	}
+	query += ` ORDER BY a.created_at DESC, a.id DESC`
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/api/migrations/20260520000000_add_tags_lower_name_unique_index.down.sql
+++ b/api/migrations/20260520000000_add_tags_lower_name_unique_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS uniq_tags_lower_name;

--- a/api/migrations/20260520000000_add_tags_lower_name_unique_index.down.sql
+++ b/api/migrations/20260520000000_add_tags_lower_name_unique_index.down.sql
@@ -1,1 +1,3 @@
+-- 削除した tags_name_key を復活させてから式インデックスを落とす。
+ALTER TABLE tags ADD CONSTRAINT tags_name_key UNIQUE (name);
 DROP INDEX IF EXISTS uniq_tags_lower_name;

--- a/api/migrations/20260520000000_add_tags_lower_name_unique_index.up.sql
+++ b/api/migrations/20260520000000_add_tags_lower_name_unique_index.up.sql
@@ -1,0 +1,4 @@
+-- tags.name を大文字小文字を区別せずユニーク扱いするための部分式インデックス。
+-- アプリ層では NormalizeTagNames が原文ケースを残すようになったので、"Vue" と "vue" を
+-- 同一タグとして扱う制約は DB 側で担保する。
+CREATE UNIQUE INDEX uniq_tags_lower_name ON tags (LOWER(name));

--- a/api/migrations/20260520000000_add_tags_lower_name_unique_index.up.sql
+++ b/api/migrations/20260520000000_add_tags_lower_name_unique_index.up.sql
@@ -2,3 +2,7 @@
 -- アプリ層では NormalizeTagNames が原文ケースを残すようになったので、"Vue" と "vue" を
 -- 同一タグとして扱う制約は DB 側で担保する。
 CREATE UNIQUE INDEX uniq_tags_lower_name ON tags (LOWER(name));
+
+-- 旧 UNIQUE (name) は uniq_tags_lower_name に含意される（同じ name は同じ LOWER に潰れるため）。
+-- 制約が 2 つ並ぶとどちらが効いているのか分かりにくく、INSERT のインデックス更新も二重になるので削除。
+ALTER TABLE tags DROP CONSTRAINT tags_name_key;

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -806,7 +806,8 @@ paths:
       - replies
   /api/tags:
     get:
-      description: Get tag candidates for creating articles.
+      description: Get all tag names. Used for tag candidates on the article list
+        / create screens. No auth required.
       produces:
       - application/json
       responses:
@@ -814,16 +815,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/server.listTagsResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/server.tagsErrorResponse'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/server.tagsErrorResponse'
-      security:
-      - BearerAuth: []
       summary: List tags
       tags:
       - article

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -332,7 +332,15 @@ info:
 paths:
   /api/articles:
     get:
-      description: Get article list API.
+      description: Get article list API. Supports filtering by tag name (AND).
+      parameters:
+      - collectionFormat: multi
+        description: Filter by tag name (multiple = AND)
+        in: query
+        items:
+          type: string
+        name: tag
+        type: array
       produces:
       - application/json
       responses:
@@ -340,6 +348,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/server.listArticlesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/server.articleErrorResponse'
         "500":
           description: Internal Server Error
           schema:

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -14,7 +14,7 @@
     "paths": {
         "/api/articles": {
             "get": {
-                "description": "Get article list API.",
+                "description": "Get article list API. Supports filtering by tag name (AND).",
                 "produces": [
                     "application/json"
                 ],
@@ -22,11 +22,29 @@
                     "article"
                 ],
                 "summary": "List articles",
+                "parameters": [
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Filter by tag name (multiple = AND)",
+                        "name": "tag",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/server.listArticlesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/server.articleErrorResponse"
                         }
                     },
                     "500": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -745,12 +745,7 @@
         },
         "/api/tags": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get tag candidates for creating articles.",
+                "description": "Get all tag names. Used for tag candidates on the article list / create screens. No auth required.",
                 "produces": [
                     "application/json"
                 ],
@@ -763,12 +758,6 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/server.listTagsResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/server.tagsErrorResponse"
                         }
                     },
                     "500": {

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -15,6 +15,10 @@ export const AUTH_TOKEN_STORAGE_KEY = 'auth_token'
 
 export const api = new Api({ baseURL })
 
+// 配列クエリは `?tag=a&tag=b`（OpenAPI の collectionFormat: multi）形式で送る。
+// axios のデフォルトは `tag[]=a&tag[]=b` で、Gin の c.QueryArray("tag") が拾えないため。
+api.instance.defaults.paramsSerializer = { indexes: null }
+
 type ApiErrorHandler = (status: number | null) => void
 
 let apiErrorHandler: ApiErrorHandler | null = null

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -369,17 +369,24 @@ export class Api<
 > extends HttpClient<SecurityDataType> {
   api = {
     /**
-     * @description Get article list API.
+     * @description Get article list API. Supports filtering by tag name (AND).
      *
      * @tags article
      * @name ArticlesList
      * @summary List articles
      * @request GET:/api/articles
      */
-    articlesList: (params: RequestParams = {}) =>
+    articlesList: (
+      query?: {
+        /** Filter by tag name (multiple = AND) */
+        tag?: string[];
+      },
+      params: RequestParams = {},
+    ) =>
       this.request<ServerListArticlesResponse, ServerArticleErrorResponse>({
         path: `/api/articles`,
         method: "GET",
+        query: query,
         format: "json",
         ...params,
       }),

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -645,19 +645,17 @@ export class Api<
       }),
 
     /**
-     * @description Get tag candidates for creating articles.
+     * @description Get all tag names. Used for tag candidates on the article list / create screens. No auth required.
      *
      * @tags article
      * @name TagsList
      * @summary List tags
      * @request GET:/api/tags
-     * @secure
      */
     tagsList: (params: RequestParams = {}) =>
       this.request<ServerListTagsResponse, ServerTagsErrorResponse>({
         path: `/api/tags`,
         method: "GET",
-        secure: true,
         format: "json",
         ...params,
       }),

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -47,17 +47,10 @@ const clearTag = () => {
   selectedTags.value = []
 }
 
-const articleTagNames = computed(() => {
-  const tagNames = new Set<string>()
-
-  for (const article of articles.value) {
-    for (const tag of article.tags ?? []) {
-      tagNames.add(tag.name)
-    }
-  }
-
-  return [...tagNames].sort((a, b) => a.localeCompare(b))
-})
+// ドロップダウンの候補は記事の絞り込みとは独立に取得する。
+// articles から導出してしまうと「現在の絞り込み結果と共起するタグ」しか出なくなり、
+// 他カテゴリへの切り替え動線が失われるため。
+const tagCandidates = ref<string[]>([])
 
 const fetchArticles = async () => {
   loading.value = true
@@ -74,10 +67,21 @@ const fetchArticles = async () => {
   }
 }
 
+const fetchTagCandidates = async () => {
+  try {
+    const response = await api.api.tagsList()
+    tagCandidates.value = response.data.tags?.map((tag) => tag.name) ?? []
+  } catch {
+    // 候補取得に失敗してもページは使えるようにする（記事カード経由でタグ選択は可能）。
+    tagCandidates.value = []
+  }
+}
+
 onMounted(() => {
   if (notificationStore.consumeCreated()) {
     showCreatedAlert.value = true
   }
+  void fetchTagCandidates()
 })
 
 // URL の tag クエリが変わるたびにサーバ側で再フィルタした結果を取得する。
@@ -100,7 +104,7 @@ watch(selectedTags, () => void fetchArticles(), { immediate: true })
 
         <v-select
           v-model="selectedTags"
-          :items="articleTagNames"
+          :items="tagCandidates"
           label="タグで絞り込み"
           prepend-inner-icon="mdi-tag-outline"
           variant="outlined"

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import ArticleCard from './ArticleCard.vue'
 import type { ServerArticleJSONResponse } from '@/api/generated/apiSchema'
 import { api } from '@/api/client'
 import { useArticleNotificationStore } from '@/stores/articleNotification'
 
-type ArticleTag = NonNullable<ServerArticleJSONResponse['tags']>[number]
+const route = useRoute()
+const router = useRouter()
 
 const articles = ref<ServerArticleJSONResponse[]>([])
 const loading = ref(false)
@@ -14,17 +16,31 @@ const error = ref<string | null>(null)
 const showCreatedAlert = ref(false)
 const notificationStore = useArticleNotificationStore()
 
-const selectedTags = ref<string[]>([])
-const tagCandidates = ref<string[]>([])
+// URL の ?tag=... を唯一の真実として selectedTags を扱う。
+// リロード / ブックマーク / 共有リンクで絞り込み状態を再現できるようにするため、
+// ローカル ref ではなく route.query と双方向にバインドする。
+const selectedTags = computed<string[]>({
+  get() {
+    const q = route.query.tag
+    if (Array.isArray(q)) {
+      return q.filter((t): t is string => typeof t === 'string' && t.length > 0)
+    }
+    if (typeof q === 'string' && q.length > 0) return [q]
+    return []
+  },
+  set(next) {
+    // フィルタ操作 1 回ごとに履歴を積むと「戻る」が壊れるので push ではなく replace。
+    void router.replace({
+      query: { ...route.query, tag: next.length ? next : undefined },
+    })
+  },
+})
 
 const toggleTag = (tagName: string) => {
-  const index = selectedTags.value.indexOf(tagName)
-
-  if (index === -1) {
-    selectedTags.value.push(tagName)
-  } else {
-    selectedTags.value.splice(index, 1)
-  }
+  const current = selectedTags.value
+  const index = current.indexOf(tagName)
+  selectedTags.value =
+    index === -1 ? [...current, tagName] : current.filter((_, i) => i !== index)
 }
 
 const clearTag = () => {
@@ -43,41 +59,29 @@ const articleTagNames = computed(() => {
   return [...tagNames].sort((a, b) => a.localeCompare(b))
 })
 
-const filterTagItems = computed(() => {
-  if (tagCandidates.value.length > 0) {
-    return tagCandidates.value
-  }
-
-  return articleTagNames.value
-})
-
-const filteredArticles = computed(() => {
-  if (selectedTags.value.length === 0) return articles.value
-
-  return articles.value.filter((article) =>
-    selectedTags.value.every((tagName) =>
-      article.tags?.some((tag: ArticleTag) => tag.name === tagName),
-    ),
-  )
-})
-
-onMounted(async () => {
-  if (notificationStore.consumeCreated()) {
-    showCreatedAlert.value = true
-  }
-
+const fetchArticles = async () => {
   loading.value = true
+  error.value = null
   try {
-    const response = await api.api.articlesList()
+    const response = await api.api.articlesList({
+      tag: selectedTags.value.length ? selectedTags.value : undefined,
+    })
     articles.value = response.data.articles ?? []
   } catch {
     error.value = '記事の取得に失敗しました。時間をおいて再度お試しください。'
   } finally {
     loading.value = false
   }
+}
 
-  tagCandidates.value = []
+onMounted(() => {
+  if (notificationStore.consumeCreated()) {
+    showCreatedAlert.value = true
+  }
 })
+
+// URL の tag クエリが変わるたびにサーバ側で再フィルタした結果を取得する。
+watch(selectedTags, () => void fetchArticles(), { immediate: true })
 </script>
 
 <template>
@@ -96,7 +100,7 @@ onMounted(async () => {
 
         <v-select
           v-model="selectedTags"
-          :items="filterTagItems"
+          :items="articleTagNames"
           label="タグで絞り込み"
           prepend-inner-icon="mdi-tag-outline"
           variant="outlined"
@@ -149,18 +153,14 @@ onMounted(async () => {
 
         <div v-else class="d-flex flex-column ga-4">
           <ArticleCard
-            v-for="article in filteredArticles"
+            v-for="article in articles"
             :key="article.id"
             :article="article"
             :selected-tags="selectedTags"
             @select-tag="toggleTag"
           />
 
-          <v-alert
-            v-if="filteredArticles.length === 0"
-            type="info"
-            variant="tonal"
-          >
+          <v-alert v-if="articles.length === 0" type="info" variant="tonal">
             該当する記事はありません
           </v-alert>
         </div>


### PR DESCRIPTION
## やったこと

記事一覧のタグ絞り込みを、ローカル ref ベース → **URL クエリ駆動**に変更し、ついでに seed と create フローで噛み合っていなかった **タグ名の大文字小文字正規化** を整理しました。

詳細はコミットメッセージ参照: 4a5af1e

### 背景
- これまで `selectedTags` は `ArticlesView` のローカル `ref`。リロード / 共有リンク / 戻るボタンで絞り込み状態が消えていた
- フィルタはフロントで全件取得後に絞り込んでいた（バックエンドに `?tag=` が無かった）
- seed のタグは原文ケース（`Vue`, `Go`）、`NormalizeTagNames` は lowercase 化、`upsertTag` は case-sensitive。これらが噛み合わず、サーバ側でフィルタを実装すると `?tag=Vue` が seed の `Vue` 行にヒットしない事象が発生

### 主要な設計判断
- 「**保存は原文ケース / 比較は LOWER**」に統一（A: seed を lowercase 化、B: 比較を緩める、C: B + DB 制約 で C を採用）
- DB 側に `UNIQUE(LOWER(name))` を貼って dup tag を制約レベルで防止
- フロントは `selectedTags = computed<{ get, set }>` で `route.query.tag` と双方向バインド。`router.replace` で履歴を汚さない
- axios の `paramsSerializer.indexes = null` で OpenAPI の `collectionFormat: multi` と整合させる

## 動作確認

```
?tag=Vue → 1 件
?tag=vue → 1 件
?tag=VUE → 1 件
?tag=Go&tag=REST API → AND 絞り込み正常（1 件: "Goで作るREST API入門"）
```

- [x] `go build ./...`
- [x] `npm run lint`（type-check + eslint）
- [x] migration 適用（`docker compose up migrate`）

## レビュー観点

- `api/internal/article/article.go` — `NormalizeTagNames` の dedup を case-insensitive に
- `api/internal/article/repository/create_article.go` — `upsertTag` を `LOWER(name)` ベースに
- `api/internal/article/repository/get_list_articles.go` — タグフィルタ SQL（AND セマンティクス）
- `app/src/features/articles/ArticlesView.vue` — `selectedTags` を URL と双方向バインドする `computed`
- `app/src/api/client.ts` — `paramsSerializer.indexes = null`

## 注意事項

- **base = `feature/233`**: このブランチは #234 から派生しているため、レビューを綺麗にする目的で base を #234 に向けています。#234 が merge されたら自動的に develop ベース相当の diff になります
- **既存 dev DB の case-collision dup tag**: 手動で `Vue` と `vue` 両方を投入している人がいると `UNIQUE(LOWER(name))` migration が落ちます。merge アナウンス時に dev DB のリセットか手動 dedup を周知してください

## 残課題 / 別 PR 候補

1. タグドロップダウンの候補が「フィルタ結果と共起するタグ」に縮小される。`/api/tags` を public 化して候補を独立に供給するのが筋
2. 新しい `?tag=` クエリの Go テスト（AND / case-insensitive / 不正値 / 空クエリ）
3. `tags.name` の `UNIQUE` 制約が `UNIQUE(LOWER(name))` 追加で冗長化（cleanup PR 候補）
4. `useArticleNotificationStore` を `history.state` 経由に置換可能（Pinia レビュー時の別件 / 優先度低）

🤖 Generated with [Claude Code](https://claude.com/claude-code)