### PR TITLE
絞り込み機能の追加

### DIFF
--- a/app/src/features/replies/ReplySection.vue
+++ b/app/src/features/replies/ReplySection.vue
@@ -116,7 +116,6 @@ const bestAnswerPathIds = computed(() => {
   return set
 })
 
-
 const effectiveBestAnswerPathIds = computed(() => {
   // フィルター中はベストアンサー経路を無効化
   if (currentFilter.value !== 'all') {
@@ -124,7 +123,6 @@ const effectiveBestAnswerPathIds = computed(() => {
   }
   return bestAnswerPathIds.value
 })
-
 
 // 各リプライについて、そのサブツリーで「ベストアンサー経路に乗っていない子孫」の総数。
 // ネストの奥に隠れている件数もまとめて数えたいので、メモ化付き DFS で一括算出する。
@@ -150,9 +148,6 @@ const hiddenDescendantCountByReplyId = computed(() => {
   for (const r of replies.value) compute(r.id)
   return result
 })
-
-
-
 
 // 各リプライについて、その親が質問（kind=question）なら親の user_id を記録する Map。
 // key = 子の reply.id, value = 質問の user_id。

--- a/app/src/features/replies/ReplySection.vue
+++ b/app/src/features/replies/ReplySection.vue
@@ -116,9 +116,20 @@ const bestAnswerPathIds = computed(() => {
   return set
 })
 
+
+const effectiveBestAnswerPathIds = computed(() => {
+  // フィルター中はベストアンサー経路を無効化
+  if (currentFilter.value !== 'all') {
+    return new Set<number>()
+  }
+  return bestAnswerPathIds.value
+})
+
+
 // 各リプライについて、そのサブツリーで「ベストアンサー経路に乗っていない子孫」の総数。
 // ネストの奥に隠れている件数もまとめて数えたいので、メモ化付き DFS で一括算出する。
 // これをルートの「返信 N 件を表示」ボタンのカウントに使うことで、ボタンを 1 つだけ出せる。
+
 const hiddenDescendantCountByReplyId = computed(() => {
   const result = new Map<number, number>()
   const compute = (id: number): number => {
@@ -127,7 +138,7 @@ const hiddenDescendantCountByReplyId = computed(() => {
     const kids = childrenByParent.value.get(id) ?? []
     let total = 0
     for (const k of kids) {
-      if (bestAnswerPathIds.value.has(k.id)) {
+      if (effectiveBestAnswerPathIds.value.has(k.id)) {
         total += compute(k.id)
       } else {
         total += 1 + (descendantCountByParent.value.get(k.id) ?? 0)
@@ -139,6 +150,9 @@ const hiddenDescendantCountByReplyId = computed(() => {
   for (const r of replies.value) compute(r.id)
   return result
 })
+
+
+
 
 // 各リプライについて、その親が質問（kind=question）なら親の user_id を記録する Map。
 // key = 子の reply.id, value = 質問の user_id。
@@ -264,7 +278,7 @@ watch(
         :reply="reply"
         :children-by-parent="childrenByParent"
         :descendant-count-by-parent="descendantCountByParent"
-        :best-answer-path-ids="bestAnswerPathIds"
+        :best-answer-path-ids="effectiveBestAnswerPathIds"
         :hidden-descendant-count-by-reply-id="hiddenDescendantCountByReplyId"
         :reveal-all="false"
         :depth="0"

--- a/app/src/features/replies/ReplySection.vue
+++ b/app/src/features/replies/ReplySection.vue
@@ -25,6 +25,19 @@ const loading = ref(false)
 const error = ref<string | null>(null)
 const currentUserId = ref<number | null>(null)
 
+const currentFilter = ref<'all' | 'comment' | 'question'>('all')
+
+const counts = computed(() => {
+  const c = { all: 0, comment: 0, question: 0 }
+  for (const r of replies.value) {
+    if (r.parent_id != null) continue
+    c.all++
+    if (r.kind === 'question') c.question++
+    else if (r.kind === 'comment') c.comment++
+  }
+  return c
+})
+
 onMounted(async () => {
   if (!isAuthenticated.value) return
   try {
@@ -78,6 +91,11 @@ const rootReplies = computed(() =>
         new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
     ),
 )
+
+const filteredRootReplies = computed(() => {
+  if (currentFilter.value === 'all') return rootReplies.value
+  return rootReplies.value.filter((r) => r.kind === currentFilter.value)
+})
 
 // ベストアンサー自身と、その全祖先の id 集合。
 // 初期表示ではこの集合に含まれるリプライだけを見せ、他は「N 件を表示」ボタンの裏に隠す。
@@ -199,6 +217,18 @@ watch(
       </div>
     </v-card>
 
+    <v-btn-toggle
+      v-model="currentFilter"
+      mandatory
+      variant="outlined"
+      density="comfortable"
+      color="primary"
+    >
+      <v-btn value="all">すべて ({{ counts.all }})</v-btn>
+      <v-btn value="comment">コメント ({{ counts.comment }})</v-btn>
+      <v-btn value="question">質問 ({{ counts.question }})</v-btn>
+    </v-btn-toggle>
+
     <v-skeleton-loader
       v-if="loading"
       type="paragraph, paragraph"
@@ -215,15 +245,21 @@ watch(
     </v-alert>
 
     <div
-      v-else-if="rootReplies.length === 0"
+      v-else-if="filteredRootReplies.length === 0"
       class="text-body-2 text-medium-emphasis text-center py-6"
     >
-      まだリプライはありません
+      <template v-if="currentFilter === 'all'">
+        まだリプライはありません
+      </template>
+      <template v-else-if="currentFilter === 'comment'">
+        コメントはありません
+      </template>
+      <template v-else> 質問はありません </template>
     </div>
 
     <div v-else class="d-flex flex-column ga-4">
       <ReplyThread
-        v-for="reply in rootReplies"
+        v-for="reply in filteredRootReplies"
         :key="reply.id"
         :reply="reply"
         :children-by-parent="childrenByParent"

--- a/app/src/features/replies/ReplySection.vue
+++ b/app/src/features/replies/ReplySection.vue
@@ -117,10 +117,8 @@ const bestAnswerPathIds = computed(() => {
 })
 
 const effectiveBestAnswerPathIds = computed(() => {
-  // フィルター中はベストアンサー経路を無効化
-  if (currentFilter.value !== 'all') {
-    return new Set<number>()
-  }
+  // フィルター時も「すべて」と同じ表示ロジック（ベストアンサー経路のみ表示し、他は隠す）
+  // を適用する。
   return bestAnswerPathIds.value
 })
 

--- a/app/src/features/replies/ReplyThread.vue
+++ b/app/src/features/replies/ReplyThread.vue
@@ -48,25 +48,7 @@ const visibleChildren = computed(() => {
     return children.value
   }
 
-  if (props.depth === 0 && bestDescendant.value) {
-    return [bestDescendant.value]
-  }
-
-  return []
-})
-
-const bestDescendant = computed<ServerReplyJSONResponse | null>(() => {
-  const stack = [...children.value]
-
-  while (stack.length > 0) {
-    const node = stack.pop()!
-    if (node.is_best) return node
-
-    const kids = props.childrenByParent.get(node.id) ?? []
-    stack.push(...kids)
-  }
-
-  return null
+  return children.value.filter((child) => props.bestAnswerPathIds.has(child.id))
 })
 
 // 隠れている件数はサブツリー全体で集計済みのものを参照する。

--- a/app/src/features/replies/ReplyThread.vue
+++ b/app/src/features/replies/ReplyThread.vue
@@ -55,7 +55,6 @@ const visibleChildren = computed(() => {
   return []
 })
 
-
 const bestDescendant = computed<ServerReplyJSONResponse | null>(() => {
   const stack = [...children.value]
 
@@ -69,8 +68,6 @@ const bestDescendant = computed<ServerReplyJSONResponse | null>(() => {
 
   return null
 })
-
-
 
 // 隠れている件数はサブツリー全体で集計済みのものを参照する。
 // ネストの奥（例: ベストアンサーの下の返信）も合算したうえで、ボタン 1 つで全部開けるようにするため。

--- a/app/src/features/replies/ReplyThread.vue
+++ b/app/src/features/replies/ReplyThread.vue
@@ -43,11 +43,34 @@ const effectiveReveal = computed(() => props.revealAll || localReveal.value)
 
 // 初期表示で見せる子の集合。
 // 全表示モードなら children すべて、そうでなければベストアンサー経路に乗っている子だけ。
-const visibleChildren = computed(() =>
-  effectiveReveal.value
-    ? children.value
-    : children.value.filter((c) => props.bestAnswerPathIds.has(c.id)),
-)
+const visibleChildren = computed(() => {
+  if (effectiveReveal.value) {
+    return children.value
+  }
+
+  if (props.depth === 0 && bestDescendant.value) {
+    return [bestDescendant.value]
+  }
+
+  return []
+})
+
+
+const bestDescendant = computed<ServerReplyJSONResponse | null>(() => {
+  const stack = [...children.value]
+
+  while (stack.length > 0) {
+    const node = stack.pop()!
+    if (node.is_best) return node
+
+    const kids = props.childrenByParent.get(node.id) ?? []
+    stack.push(...kids)
+  }
+
+  return null
+})
+
+
 
 // 隠れている件数はサブツリー全体で集計済みのものを参照する。
 // ネストの奥（例: ベストアンサーの下の返信）も合算したうえで、ボタン 1 つで全部開けるようにするため。


### PR DESCRIPTION
## 概要

記事リプライに対して「すべて・コメント・質問」で絞り込みできる機能を追加しました。  
ユーザーが目的の投稿へ素早くアクセスできることを目的としています。

---

## 変更内容

### 状態管理の追加
- `currentFilter` ('all', 'comment', 'question') を追加し、フィルター状態を管理

### 算出プロパティの実装
- `counts`
  - 各フィルターに対応するスレッド件数をリアルタイムで算出
- `filteredRootReplies`
  - 選択されたフィルターに応じてルートリプライを抽出

### UIの追加・更新
- `ReplyForm` の直下に `v-btn-toggle` を配置
- フィルターボタン（すべて / コメント / 質問）を追加
- 件数をボタンに表示
- アクティブ状態を視覚的に分かるように改善
- フィルター結果が0件の場合のメッセージを追加

### 既存機能との統合
- 質問をフィルタリングした際、紐づく回答も表示される既存の `ReplyThread` の挙動を維持

---

## 設計意図

- フィルターはルートリプライ単位で行い、スレッド構造は維持する
- 質問のみ表示した場合でも回答を含めて表示することで文脈を保つ
- 件数表示によってユーザーがコンテンツ量を把握しやすくする

---

## 影響範囲

- ReplySection.vue（UI / 状態管理）
- リプライ表示ロジック（root単位のフィルタリング）

---

## 補足

- ベストアンサー表示ロジックとの互換性を保ったまま実装
- スレッド構造を維持することでUXの崩れを防止

---

## 動作確認

- [x] 初期表示で「すべて」が選択されている
- [x] 「コメント」でコメントのみ表示される
- [x] 「質問」で質問＋回答が表示される
- [x] 件数が正しく表示される
- [x] 0件時のメッセージが表示される
- [x] フィルター切り替えが即時反映される

---

## 動作確認「写真」
<img width="877" height="514" alt="スクリーンショット 2026-05-21 102629" src="https://github.com/user-attachments/assets/48d4ee88-9bdd-40f8-84af-2248c188a175" />
<img width="827" height="471" alt="スクリーンショット 2026-05-21 102639" src="https://github.com/user-attachments/assets/883ec499-1563-4549-96e7-3a640d64ceae" />



---


Closes #236