### PR TITLE
feat: 新規記事作成画面を Markdown 記法対応に変更 phase2

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,6 +15,7 @@
         "github-markdown-css": "^5.9.0",
         "highlight.js": "^11.11.1",
         "markdown-it": "^14.1.1",
+        "md-editor-v3": "^6.5.0",
         "pinia": "^3.0.4",
         "vue": "^3.5.32",
         "vue-router": "^4.6.4",
@@ -598,6 +599,407 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
+      "integrity": "sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-angular": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-angular/-/lang-angular-0.1.4.tgz",
+      "integrity": "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.3"
+      }
+    },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz",
+      "integrity": "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-go": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-go/-/lang-go-6.0.1.tgz",
+      "integrity": "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/go": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-jinja": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.1.tgz",
+      "integrity": "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-less": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-less/-/lang-less-6.0.2.tgz",
+      "integrity": "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-liquid": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-liquid/-/lang-liquid-6.3.2.tgz",
+      "integrity": "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/lang-rust": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz",
+      "integrity": "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
+      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/sass": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-vue": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz",
+      "integrity": "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-wast": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
+      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/language-data": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.5.2.tgz",
+      "integrity": "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-angular": "^0.1.0",
+        "@codemirror/lang-cpp": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-go": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-java": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/lang-jinja": "^6.0.0",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-less": "^6.0.0",
+        "@codemirror/lang-liquid": "^6.0.0",
+        "@codemirror/lang-markdown": "^6.0.0",
+        "@codemirror/lang-php": "^6.0.0",
+        "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/lang-rust": "^6.0.0",
+        "@codemirror/lang-sass": "^6.0.0",
+        "@codemirror/lang-sql": "^6.0.0",
+        "@codemirror/lang-vue": "^0.1.1",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lang-yaml": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/legacy-modes": "^6.4.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.3.tgz",
+      "integrity": "sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
+      "integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
+      "integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1362,6 +1764,189 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/cpp": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.5.tgz",
+      "integrity": "sha512-DIhSXmYtJKLehrjzDFN+2cPt547ySQ41nA8yqcDf/GxMc+YM736xqltFkvADL2M0VebU5I+3+4ks2Vv+Kyq3Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/go": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/go/-/go-1.0.1.tgz",
+      "integrity": "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.18.tgz",
+      "integrity": "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/rust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
+      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz",
+      "integrity": "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
     "node_modules/@mdi/font": {
       "version": "7.4.47",
       "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
@@ -2099,14 +2684,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "^5",
@@ -2117,7 +2700,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2410,6 +2992,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@vavt/copy2clipboard": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@vavt/copy2clipboard/-/copy2clipboard-1.0.3.tgz",
+      "integrity": "sha512-HtG48r2FBYp9eRvGB3QGmtRBH1zzRRAVvFbGgFstOwz4/DDaNiX0uZc3YVKPydqgOav26pibr9MtoCaWxn7aeA==",
+      "license": "MIT"
+    },
+    "node_modules/@vavt/util": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vavt/util/-/util-2.1.2.tgz",
+      "integrity": "sha512-L3UbSJthJwr3wq0x93O5TrCepimrmVZaIl2ciZbeL18G5++gBhJXNhcH7RcVk/6rr3SavWOvwhig0mqRLoR7dw==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.6",
@@ -3130,6 +3724,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3161,6 +3770,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -3214,6 +3829,12 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3279,6 +3900,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4925,6 +5552,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-vue-next": {
+      "version": "0.543.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-0.543.0.tgz",
+      "integrity": "sha512-Az5kpNm/koKAwSNIKjsZ4uHV2tVfmlQlcHwFBygQ8gc5/jFg7An9OrxgDy/aE5m+HLx7VfLYqDxLr8gWecZbQA==",
+      "deprecated": "Package deprecated. Please use @lucide/vue instead.",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
+    },
     "node_modules/magic-regexp": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/magic-regexp/-/magic-regexp-0.10.0.tgz",
@@ -4993,6 +5630,30 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-it-image-figures": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-image-figures/-/markdown-it-image-figures-2.1.1.tgz",
+      "integrity": "sha512-mwXSQ2nPeVUzCMIE3HlLvjRioopiqyJLNph0pyx38yf9mpqFDhNGnMpAXF9/A2Xv0oiF2cVyg9xwfF0HNAz05g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/markdown-it-sub": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-sub/-/markdown-it-sub-2.0.0.tgz",
+      "integrity": "sha512-iCBKgwCkfQBRg2vApy9vx1C1Tu6D8XYo8NvevI3OlwzBRmiMtsJ2sXupBgEA7PPxiDwNni3qIUkhZ6j5wofDUA==",
+      "license": "MIT"
+    },
+    "node_modules/markdown-it-sup": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-sup/-/markdown-it-sup-2.0.0.tgz",
+      "integrity": "sha512-5VgmdKlkBd8sgXuoDoxMpiU+BiEt3I49GItBzzw7Mxq9CxvnhE/k09HFli09zgfFDRixDQDfDxi0mgBCXtaTvA==",
+      "license": "MIT"
+    },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -5014,6 +5675,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/md-editor-v3": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/md-editor-v3/-/md-editor-v3-6.5.0.tgz",
+      "integrity": "sha512-GhGhPebfJeOrFuybFMUZRM6GzLMhu7Sg03MWLwO6tuIKMkRN71/SeTbLYYzY95qpaMbXDMWKlTkj3UNf9Bz4dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.18.7",
+        "@codemirror/commands": "^6.8.1",
+        "@codemirror/lang-markdown": "^6.3.4",
+        "@codemirror/language": "^6.11.3",
+        "@codemirror/language-data": "^6.5.1",
+        "@codemirror/search": "^6.5.11",
+        "@codemirror/state": "^6.5.2",
+        "@codemirror/view": "^6.38.2",
+        "@lezer/highlight": "^1.2.1",
+        "@types/markdown-it": "^14.0.1",
+        "@vavt/copy2clipboard": "^1.0.1",
+        "@vavt/util": "^2.1.2",
+        "codemirror": "^6.0.2",
+        "lucide-vue-next": "^0.543.0",
+        "markdown-it": "^14.0.0",
+        "markdown-it-image-figures": "^2.1.1",
+        "markdown-it-sub": "^2.0.0",
+        "markdown-it-sup": "^2.0.0",
+        "medium-zoom": "^1.1.0",
+        "xss": "^1.0.15"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.3"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -5025,6 +5717,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/medium-zoom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.1.0.tgz",
+      "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==",
       "license": "MIT"
     },
     "node_modules/memorystream": {
@@ -6187,6 +6885,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/superjson": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
@@ -6983,6 +7687,12 @@
         }
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -7092,6 +7802,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/y18n": {

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
     "github-markdown-css": "^5.9.0",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.1.1",
+    "md-editor-v3": "^6.5.0",
     "pinia": "^3.0.4",
     "vue": "^3.5.32",
     "vue-router": "^4.6.4",

--- a/app/src/features/articles/NewArticleView.vue
+++ b/app/src/features/articles/NewArticleView.vue
@@ -74,15 +74,13 @@ onMounted(async () => {
 </script>
 
 <template>
-  <v-sheet color="grey-lighten-4" class="page-sheet">
-    <div class="article-editor px-md-8 px-4 py-4">
+  <v-sheet color="grey-lighten-4" class="page-bg">
+    <v-container max-width="1200" class="editor-wrap">
       <v-form ref="formRef" class="article-form" @submit.prevent="submit">
-        <!-- ページ上部アクションバー: 投稿ボタンのみ -->
-        <div class="action-bar d-flex justify-end py-2 mb-2">
+        <div class="d-flex justify-end mb-3">
           <v-btn
             type="submit"
             color="black"
-            size="default"
             class="px-6"
             :loading="submitting"
             :disabled="!canSubmit"
@@ -101,118 +99,115 @@ onMounted(async () => {
           {{ submitError }}
         </v-alert>
 
-        <!-- タイトル -->
-        <v-text-field
-          v-model="form.title"
-          placeholder="タイトルを入力"
-          aria-label="タイトル"
-          variant="plain"
-          density="comfortable"
-          maxlength="200"
-          :rules="[(v) => !!v || 'タイトルは必須です']"
-          validate-on="input"
-          class="title-input"
-        />
-
-        <v-divider />
-
-        <!-- タグ -->
-        <v-combobox
-          v-model="form.tags"
-          placeholder="タグを入力してEnter（スペース区切りで複数可）"
-          aria-label="タグ"
-          variant="plain"
-          density="comfortable"
-          :items="tagCandidates"
-          multiple
-          chips
-          closable-chips
-          prepend-inner-icon="mdi-tag-outline"
-        />
-
-        <v-divider class="mb-2" />
-
-        <!-- 本文（編集 / プレビュー タブ切替） -->
-        <v-tabs
-          v-model="bodyTab"
-          density="comfortable"
-          color="primary"
-          class="mb-2"
-        >
-          <v-tab value="edit">編集</v-tab>
-          <v-tab value="preview">プレビュー</v-tab>
-        </v-tabs>
-
-        <!-- 編集 / プレビューの切替は v-show で行う。
-           v-window はスライドアニメーションが副作用で残るため不採用。
-           textarea を v-show で残し続けると入力状態 (caret / スクロール位置) も保たれる。 -->
-        <div class="editor-area">
-          <v-textarea
-            v-show="bodyTab === 'edit'"
-            v-model="form.body"
-            placeholder="本文を入力（Markdown）"
-            aria-label="本文"
+        <v-sheet rounded class="editor-card pa-4 pa-md-6">
+          <v-text-field
+            v-model="form.title"
+            placeholder="タイトルを入力"
+            aria-label="タイトル"
             variant="plain"
             density="comfortable"
-            no-resize
-            maxlength="10000"
-            :rules="[(v) => !!v || '本文は必須です']"
+            maxlength="200"
+            :rules="[(v) => !!v || 'タイトルは必須です']"
             validate-on="input"
-            class="body-input"
+            class="title-input"
           />
 
-          <div v-show="bodyTab === 'preview'" class="body-preview pa-2">
-            <MarkdownContent
-              v-if="bodyTab === 'preview' && form.body.trim()"
-              :source="form.body"
+          <v-divider />
+
+          <v-combobox
+            v-model="form.tags"
+            placeholder="タグを入力してEnter"
+            aria-label="タグ"
+            variant="plain"
+            density="comfortable"
+            :items="tagCandidates"
+            multiple
+            chips
+            closable-chips
+            prepend-inner-icon="mdi-tag-outline"
+          />
+
+          <v-divider class="mb-2" />
+
+          <v-tabs
+            v-model="bodyTab"
+            density="comfortable"
+            color="primary"
+            class="mb-2"
+          >
+            <v-tab value="edit">編集</v-tab>
+            <v-tab value="preview">プレビュー</v-tab>
+          </v-tabs>
+
+          <!-- v-window のスライドアニメは不要、かつ textarea の入力状態を保つため v-show で切替 -->
+          <div class="body-area">
+            <v-textarea
+              v-show="bodyTab === 'edit'"
+              v-model="form.body"
+              placeholder="本文を入力（Markdown）"
+              aria-label="本文"
+              variant="plain"
+              density="comfortable"
+              no-resize
+              maxlength="10000"
+              :rules="[(v) => !!v || '本文は必須です']"
+              validate-on="input"
+              class="body-input"
             />
-            <div v-else-if="bodyTab === 'preview'" class="text-medium-emphasis">
-              本文がまだ入力されていません。
+
+            <div v-show="bodyTab === 'preview'" class="body-preview pa-2">
+              <MarkdownContent
+                v-if="bodyTab === 'preview' && form.body.trim()"
+                :source="form.body"
+              />
+              <div
+                v-else-if="bodyTab === 'preview'"
+                class="text-medium-emphasis"
+              >
+                本文がまだ入力されていません。
+              </div>
             </div>
           </div>
-        </div>
+        </v-sheet>
       </v-form>
-    </div>
+    </v-container>
   </v-sheet>
 </template>
 
 <style scoped>
-/* 外側 (v-sheet): v-main 領域全幅をグレーで埋める。
-   ページ自体はスクロールせず、編集エリアの内部だけがスクロールする (Qiita 同様)。 */
-.page-sheet {
+/* Qiita スタイル: ページ自体はスクロールせず、本文エリアの内部だけがスクロールする。
+   そのために v-main → page-bg → editor-wrap → article-form → editor-card → body-area
+   と高さ 100% / flex column を連鎖させる必要がある。 */
+.page-bg {
   height: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
-/* 中身を 1200px 幅で中央寄せ。グレー背景は v-sheet から透けて見える。 */
-.article-editor {
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
+.editor-wrap {
   flex: 1 1 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
 }
 
-/* v-form は flex column のチェーンを繋ぐためだけの存在。 */
-.article-form {
+/* v-form / editor-card 直下の要素は基本「自然な高さ」で積み、
+   一番下の領域 (.editor-card, .body-area) だけが残り高さを取る。 */
+.article-form,
+.editor-card,
+.body-area {
   flex: 1 1 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
 }
-
-/* Vuetify の .v-input は CSS で `flex: 1 1 auto` を持っているため、
-   そのまま flex column の子にすると全部が縦に均等ストレッチされてしまう。
-   タイトル / タグ / 区切り線 / タブなどの「上に積む要素」は自然な高さに固定し、
-   .editor-area だけが残り高さを取るようにする。 */
-.article-form > * {
+.article-form > *,
+.editor-card > * {
   flex: 0 0 auto;
 }
-.article-form > .editor-area {
+.article-form > .editor-card,
+.editor-card > .body-area {
   flex: 1 1 0;
   min-height: 0;
 }
@@ -224,21 +219,9 @@ onMounted(async () => {
   line-height: 1.3;
 }
 
-/* 編集 / プレビュー領域: flex 子要素として残り高さ全部を取り、内部だけスクロール。
-   周囲のグレー背景に対して「白い島」になる。 */
-.editor-area {
-  flex: 1 1 0;
-  min-height: 0; /* flex 子要素が縮める許可。これが無いと内部スクロールが効かない */
-  display: flex;
-  flex-direction: column;
-  background: rgb(var(--v-theme-surface)); /* グレーの上に白を載せる */
-  border-radius: 4px;
-}
-
-/* v-textarea の内部要素まで高さを伝搬させ、textarea 本体だけがスクロールするようにする。
-   auto-grow を切り、no-resize で手動リサイズも禁止。
+/* v-textarea の wrapper 階層に高さを伝搬させ、textarea 本体だけがスクロールするようにする。
    :deep() を多段に書く必要があるのは Vuetify が v-input → v-field → ... と
-   入れ子の wrapper を持つため。 */
+   wrapper を入れ子に持つため。 */
 .body-input,
 .body-input :deep(.v-input__control),
 .body-input :deep(.v-field),

--- a/app/src/features/articles/NewArticleView.vue
+++ b/app/src/features/articles/NewArticleView.vue
@@ -66,6 +66,7 @@ const canSubmit = computed(
 const submit = async () => {
   if (submitting.value) return
   if (!formRef.value) return
+  if (!form.body.trim()) return
 
   const { valid } = await formRef.value.validate()
   if (!valid) return

--- a/app/src/features/articles/NewArticleView.vue
+++ b/app/src/features/articles/NewArticleView.vue
@@ -104,18 +104,6 @@ onMounted(async () => {
   <v-sheet color="grey-lighten-4" class="page-bg">
     <v-container max-width="1200" class="editor-wrap">
       <v-form ref="formRef" class="article-form" @submit.prevent="submit">
-        <div class="d-flex justify-end mb-3">
-          <v-btn
-            type="submit"
-            color="black"
-            class="px-6"
-            :loading="submitting"
-            :disabled="!canSubmit"
-          >
-            投稿
-          </v-btn>
-        </div>
-
         <v-alert
           v-if="submitError"
           type="error"
@@ -126,20 +114,35 @@ onMounted(async () => {
           {{ submitError }}
         </v-alert>
 
-        <v-sheet rounded class="editor-card pa-4 pa-md-6">
-          <v-text-field
-            v-model="form.title"
-            placeholder="タイトルを入力"
-            aria-label="タイトル"
-            variant="plain"
-            density="comfortable"
-            maxlength="200"
-            :rules="[(v) => !!v || 'タイトルは必須です']"
-            validate-on="input"
-            class="title-input"
-          />
+        <v-sheet
+          rounded
+          class="editor-card px-4 px-md-6 pt-2 pt-md-3 pb-4 pb-md-6"
+        >
+          <div class="d-flex align-center ga-3">
+            <v-text-field
+              v-model="form.title"
+              placeholder="タイトルを入力"
+              aria-label="タイトル"
+              variant="plain"
+              density="comfortable"
+              maxlength="200"
+              :rules="[(v) => !!v || 'タイトルは必須です']"
+              validate-on="input"
+              hide-details="auto"
+              class="title-input flex-1-1"
+            />
+            <v-btn
+              type="submit"
+              color="black"
+              class="px-6 flex-shrink-0"
+              :loading="submitting"
+              :disabled="!canSubmit"
+            >
+              投稿
+            </v-btn>
+          </div>
 
-          <v-divider />
+          <v-divider class="mt-2" />
 
           <v-combobox
             v-model="form.tags"
@@ -152,6 +155,7 @@ onMounted(async () => {
             chips
             closable-chips
             prepend-inner-icon="mdi-tag-outline"
+            hide-details="auto"
           />
 
           <v-divider class="mb-2" />

--- a/app/src/features/articles/NewArticleView.vue
+++ b/app/src/features/articles/NewArticleView.vue
@@ -74,124 +74,130 @@ onMounted(async () => {
 </script>
 
 <template>
-  <v-container fluid class="px-md-8 px-4 py-4 new-article">
-    <v-form ref="formRef" class="article-form" @submit.prevent="submit">
-      <!-- ページ上部アクションバー: 投稿ボタンのみ -->
-      <div class="action-bar d-flex justify-end py-2 mb-2">
-        <v-btn
-          type="submit"
-          color="black"
-          size="default"
-          class="px-6"
-          :loading="submitting"
-          :disabled="!canSubmit"
+  <v-sheet color="grey-lighten-4" class="page-sheet">
+    <div class="article-editor px-md-8 px-4 py-4">
+      <v-form ref="formRef" class="article-form" @submit.prevent="submit">
+        <!-- ページ上部アクションバー: 投稿ボタンのみ -->
+        <div class="action-bar d-flex justify-end py-2 mb-2">
+          <v-btn
+            type="submit"
+            color="black"
+            size="default"
+            class="px-6"
+            :loading="submitting"
+            :disabled="!canSubmit"
+          >
+            投稿
+          </v-btn>
+        </div>
+
+        <v-alert
+          v-if="submitError"
+          type="error"
+          class="mb-3"
+          closable
+          @click:close="submitError = null"
         >
-          投稿
-        </v-btn>
-      </div>
+          {{ submitError }}
+        </v-alert>
 
-      <v-alert
-        v-if="submitError"
-        type="error"
-        class="mb-3"
-        closable
-        @click:close="submitError = null"
-      >
-        {{ submitError }}
-      </v-alert>
-
-      <!-- タイトル -->
-      <v-text-field
-        v-model="form.title"
-        placeholder="タイトルを入力"
-        aria-label="タイトル"
-        variant="plain"
-        density="comfortable"
-        maxlength="200"
-        :rules="[(v) => !!v || 'タイトルは必須です']"
-        validate-on="input"
-        class="title-input"
-      />
-
-      <v-divider />
-
-      <!-- タグ -->
-      <v-combobox
-        v-model="form.tags"
-        placeholder="タグを入力してEnter（スペース区切りで複数可）"
-        aria-label="タグ"
-        variant="plain"
-        density="comfortable"
-        :items="tagCandidates"
-        multiple
-        chips
-        closable-chips
-        prepend-inner-icon="mdi-tag-outline"
-      />
-
-      <v-divider class="mb-2" />
-
-      <!-- 本文（編集 / プレビュー タブ切替） -->
-      <v-tabs
-        v-model="bodyTab"
-        density="comfortable"
-        color="primary"
-        class="mb-2"
-      >
-        <v-tab value="edit">編集</v-tab>
-        <v-tab value="preview">プレビュー</v-tab>
-      </v-tabs>
-
-      <!-- 編集 / プレビューの切替は v-show で行う。
-           v-window はスライドアニメーションが副作用で残るため不採用。
-           textarea を v-show で残し続けると入力状態 (caret / スクロール位置) も保たれる。 -->
-      <div class="editor-area">
-        <v-textarea
-          v-show="bodyTab === 'edit'"
-          v-model="form.body"
-          placeholder="本文を入力（Markdown）"
-          aria-label="本文"
+        <!-- タイトル -->
+        <v-text-field
+          v-model="form.title"
+          placeholder="タイトルを入力"
+          aria-label="タイトル"
           variant="plain"
           density="comfortable"
-          no-resize
-          maxlength="10000"
-          :rules="[(v) => !!v || '本文は必須です']"
+          maxlength="200"
+          :rules="[(v) => !!v || 'タイトルは必須です']"
           validate-on="input"
-          class="body-input"
+          class="title-input"
         />
 
-        <div v-show="bodyTab === 'preview'" class="body-preview pa-2">
-          <MarkdownContent
-            v-if="bodyTab === 'preview' && form.body.trim()"
-            :source="form.body"
+        <v-divider />
+
+        <!-- タグ -->
+        <v-combobox
+          v-model="form.tags"
+          placeholder="タグを入力してEnter（スペース区切りで複数可）"
+          aria-label="タグ"
+          variant="plain"
+          density="comfortable"
+          :items="tagCandidates"
+          multiple
+          chips
+          closable-chips
+          prepend-inner-icon="mdi-tag-outline"
+        />
+
+        <v-divider class="mb-2" />
+
+        <!-- 本文（編集 / プレビュー タブ切替） -->
+        <v-tabs
+          v-model="bodyTab"
+          density="comfortable"
+          color="primary"
+          class="mb-2"
+        >
+          <v-tab value="edit">編集</v-tab>
+          <v-tab value="preview">プレビュー</v-tab>
+        </v-tabs>
+
+        <!-- 編集 / プレビューの切替は v-show で行う。
+           v-window はスライドアニメーションが副作用で残るため不採用。
+           textarea を v-show で残し続けると入力状態 (caret / スクロール位置) も保たれる。 -->
+        <div class="editor-area">
+          <v-textarea
+            v-show="bodyTab === 'edit'"
+            v-model="form.body"
+            placeholder="本文を入力（Markdown）"
+            aria-label="本文"
+            variant="plain"
+            density="comfortable"
+            no-resize
+            maxlength="10000"
+            :rules="[(v) => !!v || '本文は必須です']"
+            validate-on="input"
+            class="body-input"
           />
-          <div v-else-if="bodyTab === 'preview'" class="text-medium-emphasis">
-            本文がまだ入力されていません。
+
+          <div v-show="bodyTab === 'preview'" class="body-preview pa-2">
+            <MarkdownContent
+              v-if="bodyTab === 'preview' && form.body.trim()"
+              :source="form.body"
+            />
+            <div v-else-if="bodyTab === 'preview'" class="text-medium-emphasis">
+              本文がまだ入力されていません。
+            </div>
           </div>
         </div>
-      </div>
-    </v-form>
-  </v-container>
+      </v-form>
+    </div>
+  </v-sheet>
 </template>
 
 <style scoped>
-/* v-main の中で viewport を使い切るレイアウト。
-   ページ自体はスクロールせず、編集エリアの内部だけがスクロールする
-   (Qiita 同様)。
-   - height: 100% で v-main 領域を満たす
-   - overflow: hidden で外側のスクロールバーを抑止
-   - flex column で「上から固定の入力欄が積まれ、最後の編集エリアが残り高さを取る」構造にする */
-.new-article {
-  max-width: 1200px;
+/* 外側 (v-sheet): v-main 領域全幅をグレーで埋める。
+   ページ自体はスクロールせず、編集エリアの内部だけがスクロールする (Qiita 同様)。 */
+.page-sheet {
   height: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
-/* v-container の唯一の子である v-form が flex column のチェーンを
-   引き継がないと、内部の editor-area が「残り高さ」を計算できない。
-   form 自身を flex column 化して、編集エリアまで高さの伝搬を繋ぐ。 */
+/* 中身を 1200px 幅で中央寄せ。グレー背景は v-sheet から透けて見える。 */
+.article-editor {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* v-form は flex column のチェーンを繋ぐためだけの存在。 */
 .article-form {
   flex: 1 1 0;
   min-height: 0;
@@ -218,12 +224,15 @@ onMounted(async () => {
   line-height: 1.3;
 }
 
-/* 編集 / プレビュー領域: flex 子要素として残り高さ全部を取り、内部だけスクロール */
+/* 編集 / プレビュー領域: flex 子要素として残り高さ全部を取り、内部だけスクロール。
+   周囲のグレー背景に対して「白い島」になる。 */
 .editor-area {
   flex: 1 1 0;
   min-height: 0; /* flex 子要素が縮める許可。これが無いと内部スクロールが効かない */
   display: flex;
   flex-direction: column;
+  background: rgb(var(--v-theme-surface)); /* グレーの上に白を載せる */
+  border-radius: 4px;
 }
 
 /* v-textarea の内部要素まで高さを伝搬させ、textarea 本体だけがスクロールするようにする。

--- a/app/src/features/articles/NewArticleView.vue
+++ b/app/src/features/articles/NewArticleView.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue'
 import { useRouter } from 'vue-router'
+import { MdEditor, type ToolbarNames } from 'md-editor-v3'
+import 'md-editor-v3/lib/style.css'
 import { api } from '@/api/client'
 import { useArticleNotificationStore } from '@/stores/articleNotification'
 import MarkdownContent from './MarkdownContent.vue'
@@ -31,6 +33,31 @@ const submitting = ref(false)
 const submitError = ref<string | null>(null)
 const tagCandidates = ref<string[]>([])
 const bodyTab = ref<BodyTab>('edit')
+
+// プレビューは既存の MarkdownContent (記事詳細と同じレンダラ) で表示するため、
+// MdEditor 側のプレビュー / 全画面 / カタログ系ツールバーは除外する。
+const editorToolbars: ToolbarNames[] = [
+  'bold',
+  'underline',
+  'italic',
+  'strikeThrough',
+  '-',
+  'title',
+  'sub',
+  'sup',
+  'quote',
+  'unorderedList',
+  'orderedList',
+  'task',
+  '-',
+  'codeRow',
+  'code',
+  'link',
+  'table',
+  '-',
+  'revoke',
+  'next',
+]
 
 const canSubmit = computed(
   () => !submitting.value && !!form.title.trim() && !!form.body.trim(),
@@ -139,20 +166,18 @@ onMounted(async () => {
             <v-tab value="preview">プレビュー</v-tab>
           </v-tabs>
 
-          <!-- v-window のスライドアニメは不要、かつ textarea の入力状態を保つため v-show で切替 -->
+          <!-- v-window のスライドアニメは不要、かつ編集中のカーソル位置・履歴を保つため v-show で切替 -->
           <div class="body-area">
-            <v-textarea
+            <MdEditor
               v-show="bodyTab === 'edit'"
               v-model="form.body"
+              language="en-US"
+              theme="light"
+              :toolbars="editorToolbars"
+              :preview="false"
+              :show-code-row-number="false"
               placeholder="本文を入力（Markdown）"
-              aria-label="本文"
-              variant="plain"
-              density="comfortable"
-              no-resize
-              maxlength="10000"
-              :rules="[(v) => !!v || '本文は必須です']"
-              validate-on="input"
-              class="body-input"
+              class="body-editor"
             />
 
             <div v-show="bodyTab === 'preview'" class="body-preview pa-2">
@@ -219,19 +244,10 @@ onMounted(async () => {
   line-height: 1.3;
 }
 
-/* v-textarea の wrapper 階層に高さを伝搬させ、textarea 本体だけがスクロールするようにする。
-   :deep() を多段に書く必要があるのは Vuetify が v-input → v-field → ... と
-   wrapper を入れ子に持つため。 */
-.body-input,
-.body-input :deep(.v-input__control),
-.body-input :deep(.v-field),
-.body-input :deep(.v-field__field) {
+/* MdEditor は内部でツールバー + エディタの flex レイアウトを完結させているので、
+   外側に 100% の高さを渡すだけで残り領域いっぱいに広がる。 */
+.body-editor {
   height: 100%;
-}
-.body-input :deep(textarea) {
-  height: 100% !important;
-  overflow-y: auto !important;
-  resize: none;
 }
 
 .body-preview {

--- a/app/src/features/articles/NewArticleView.vue
+++ b/app/src/features/articles/NewArticleView.vue
@@ -3,10 +3,13 @@ import { computed, onMounted, reactive, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { api } from '@/api/client'
 import { useArticleNotificationStore } from '@/stores/articleNotification'
+import MarkdownContent from './MarkdownContent.vue'
 
 defineOptions({
   name: 'NewArticleView',
 })
+
+type BodyTab = 'edit' | 'preview'
 
 type ArticleFormRef = {
   validate: () => Promise<{ valid: boolean }>
@@ -27,6 +30,7 @@ const notificationStore = useArticleNotificationStore()
 const submitting = ref(false)
 const submitError = ref<string | null>(null)
 const tagCandidates = ref<string[]>([])
+const bodyTab = ref<BodyTab>('edit')
 
 const canSubmit = computed(
   () => !submitting.value && !!form.title.trim() && !!form.body.trim(),
@@ -70,91 +74,177 @@ onMounted(async () => {
 </script>
 
 <template>
-  <v-container class="py-12" fluid>
-    <v-row justify="center" align="start">
-      <v-col cols="12" sm="10" md="8" lg="6">
-        <v-card elevation="4" rounded="lg">
-          <v-card-title class="text-h4 font-weight-bold pa-6 pb-2">
-            新規記事作成
-          </v-card-title>
+  <v-container fluid class="px-md-8 px-4 py-4 new-article">
+    <v-form ref="formRef" class="article-form" @submit.prevent="submit">
+      <!-- ページ上部アクションバー: 投稿ボタンのみ -->
+      <div class="action-bar d-flex justify-end py-2 mb-2">
+        <v-btn
+          type="submit"
+          color="black"
+          size="default"
+          class="px-6"
+          :loading="submitting"
+          :disabled="!canSubmit"
+        >
+          投稿
+        </v-btn>
+      </div>
 
-          <v-card-text class="pa-6">
-            <v-alert
-              v-if="submitError"
-              type="error"
-              class="mb-4"
-              closable
-              @click:close="submitError = null"
-            >
-              {{ submitError }}
-            </v-alert>
+      <v-alert
+        v-if="submitError"
+        type="error"
+        class="mb-3"
+        closable
+        @click:close="submitError = null"
+      >
+        {{ submitError }}
+      </v-alert>
 
-            <v-form
-              ref="formRef"
-              class="d-flex flex-column ga-6"
-              @submit.prevent="submit"
-            >
-              <!-- タイトル -->
-              <v-text-field
-                v-model="form.title"
-                label="タイトル"
-                placeholder="タイトルを入力"
-                variant="outlined"
-                density="comfortable"
-                clearable
-                counter
-                maxlength="200"
-                :rules="[(v) => !!v || 'タイトルは必須です']"
-                validate-on="input"
-              />
+      <!-- タイトル -->
+      <v-text-field
+        v-model="form.title"
+        placeholder="タイトルを入力"
+        aria-label="タイトル"
+        variant="plain"
+        density="comfortable"
+        maxlength="200"
+        :rules="[(v) => !!v || 'タイトルは必須です']"
+        validate-on="input"
+        class="title-input"
+      />
 
-              <!-- タグ -->
-              <v-combobox
-                v-model="form.tags"
-                label="タグ"
-                placeholder="タグを入力してEnter"
-                variant="outlined"
-                density="comfortable"
-                :items="tagCandidates"
-                multiple
-                chips
-                closable-chips
-                clearable
-                hint="Enterキーでタグを追加"
-                persistent-hint
-              />
+      <v-divider />
 
-              <!-- 本文 -->
-              <v-textarea
-                v-model="form.body"
-                label="本文"
-                placeholder="本文を入力"
-                rows="10"
-                variant="outlined"
-                density="comfortable"
-                counter
-                maxlength="10000"
-                :rules="[(v) => !!v || '本文は必須です']"
-                validate-on="input"
-              />
+      <!-- タグ -->
+      <v-combobox
+        v-model="form.tags"
+        placeholder="タグを入力してEnter（スペース区切りで複数可）"
+        aria-label="タグ"
+        variant="plain"
+        density="comfortable"
+        :items="tagCandidates"
+        multiple
+        chips
+        closable-chips
+        prepend-inner-icon="mdi-tag-outline"
+      />
 
-              <!-- 投稿ボタン -->
-              <div class="mt-4">
-                <v-btn
-                  type="submit"
-                  color="black"
-                  size="large"
-                  class="px-8"
-                  :loading="submitting"
-                  :disabled="!canSubmit"
-                >
-                  投稿
-                </v-btn>
-              </div>
-            </v-form>
-          </v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
+      <v-divider class="mb-2" />
+
+      <!-- 本文（編集 / プレビュー タブ切替） -->
+      <v-tabs
+        v-model="bodyTab"
+        density="comfortable"
+        color="primary"
+        class="mb-2"
+      >
+        <v-tab value="edit">編集</v-tab>
+        <v-tab value="preview">プレビュー</v-tab>
+      </v-tabs>
+
+      <!-- 編集 / プレビューの切替は v-show で行う。
+           v-window はスライドアニメーションが副作用で残るため不採用。
+           textarea を v-show で残し続けると入力状態 (caret / スクロール位置) も保たれる。 -->
+      <div class="editor-area">
+        <v-textarea
+          v-show="bodyTab === 'edit'"
+          v-model="form.body"
+          placeholder="本文を入力（Markdown）"
+          aria-label="本文"
+          variant="plain"
+          density="comfortable"
+          no-resize
+          maxlength="10000"
+          :rules="[(v) => !!v || '本文は必須です']"
+          validate-on="input"
+          class="body-input"
+        />
+
+        <div v-show="bodyTab === 'preview'" class="body-preview pa-2">
+          <MarkdownContent
+            v-if="bodyTab === 'preview' && form.body.trim()"
+            :source="form.body"
+          />
+          <div v-else-if="bodyTab === 'preview'" class="text-medium-emphasis">
+            本文がまだ入力されていません。
+          </div>
+        </div>
+      </div>
+    </v-form>
   </v-container>
 </template>
+
+<style scoped>
+/* v-main の中で viewport を使い切るレイアウト。
+   ページ自体はスクロールせず、編集エリアの内部だけがスクロールする
+   (Qiita 同様)。
+   - height: 100% で v-main 領域を満たす
+   - overflow: hidden で外側のスクロールバーを抑止
+   - flex column で「上から固定の入力欄が積まれ、最後の編集エリアが残り高さを取る」構造にする */
+.new-article {
+  max-width: 1200px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* v-container の唯一の子である v-form が flex column のチェーンを
+   引き継がないと、内部の editor-area が「残り高さ」を計算できない。
+   form 自身を flex column 化して、編集エリアまで高さの伝搬を繋ぐ。 */
+.article-form {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Vuetify の .v-input は CSS で `flex: 1 1 auto` を持っているため、
+   そのまま flex column の子にすると全部が縦に均等ストレッチされてしまう。
+   タイトル / タグ / 区切り線 / タブなどの「上に積む要素」は自然な高さに固定し、
+   .editor-area だけが残り高さを取るようにする。 */
+.article-form > * {
+  flex: 0 0 auto;
+}
+.article-form > .editor-area {
+  flex: 1 1 0;
+  min-height: 0;
+}
+
+/* タイトル入力は記事のタイトルらしい大きさに */
+.title-input :deep(input) {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+/* 編集 / プレビュー領域: flex 子要素として残り高さ全部を取り、内部だけスクロール */
+.editor-area {
+  flex: 1 1 0;
+  min-height: 0; /* flex 子要素が縮める許可。これが無いと内部スクロールが効かない */
+  display: flex;
+  flex-direction: column;
+}
+
+/* v-textarea の内部要素まで高さを伝搬させ、textarea 本体だけがスクロールするようにする。
+   auto-grow を切り、no-resize で手動リサイズも禁止。
+   :deep() を多段に書く必要があるのは Vuetify が v-input → v-field → ... と
+   入れ子の wrapper を持つため。 */
+.body-input,
+.body-input :deep(.v-input__control),
+.body-input :deep(.v-field),
+.body-input :deep(.v-field__field) {
+  height: 100%;
+}
+.body-input :deep(textarea) {
+  height: 100% !important;
+  overflow-y: auto !important;
+  resize: none;
+}
+
+.body-preview {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+}
+</style>


### PR DESCRIPTION
## Summary
- 新規記事作成画面を Markdown 記法での入力に対応
- 本文編集エリアの背景色をグレーにして編集領域を視認しやすく調整
- なるべく素の Vuetify を使う方針でマークアップを整理

## Test plan
- [ ] 新規記事作成画面で Markdown 入力 → プレビュー表示が正しく動く
- [ ] 本文編集エリアの背景がグレーになっており、編集領域が分かりやすい
- [ ] 既存の入力項目（タイトル・タグ等）の挙動に regression がない

<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/3d3a6eca-94d8-4c0e-ae3a-c8971ded5376" />

<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/cab2fb18-e999-400b-b21e-63462c1c3060" />

<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/6ca19acd-fe74-44a5-8785-5fa5088423c9" />

Closes #238