### PR TITLE
レイアウト修正

### DIFF
--- a/app/src/components/Header.vue
+++ b/app/src/components/Header.vue
@@ -24,7 +24,14 @@ const goToLogin = () => {
 </script>
 <template>
   <v-app-bar app color="primary" dark>
-    <v-img src="/kdtech-icon.png" alt="Logo" max-width="200" class="mr-4" />
+    <v-img
+      src="/kdtech-icon.png"
+      alt="Logo"
+      max-width="200"
+      class="mr-4"
+      style="cursor: pointer"
+      @click="router.push('/')"
+    />
 
     <v-spacer></v-spacer>
 

--- a/app/src/components/Header.vue
+++ b/app/src/components/Header.vue
@@ -30,7 +30,7 @@ const goToLogin = () => {
       max-width="200"
       class="mr-4"
       style="cursor: pointer"
-      @click="router.push('/')"
+      @click="router.push('/articles')"
     />
 
     <v-spacer></v-spacer>

--- a/app/src/features/about/AboutView.vue
+++ b/app/src/features/about/AboutView.vue
@@ -1,6 +1,10 @@
 <template>
-  <main>
-    <h1>About</h1>
-    <p>KOBE-Tech についてのページです。</p>
-  </main>
+  <v-container class="py-8">
+    <v-row justify="center">
+      <v-col cols="12" sm="10">
+        <h1 class="text-h4 font-weight-bold mb-4">About</h1>
+        <p class="text-body-1">KOBE-Tech についてのページです。</p>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>

--- a/app/src/features/articles/ArticleCard.vue
+++ b/app/src/features/articles/ArticleCard.vue
@@ -20,8 +20,8 @@ const formattedDate = useDateFormat(
 </script>
 
 <template>
-  <v-card :to="`/articles/${article.id}`" class="p-4">
-    <v-card-title class="text-base font-medium">
+  <v-card :to="`/articles/${article.id}`" class="pa-4">
+    <v-card-title class="text-body-1 font-weight-medium">
       {{ article.title }}
     </v-card-title>
 
@@ -30,7 +30,7 @@ const formattedDate = useDateFormat(
         <v-chip
           v-for="tag in article.tags"
           :key="tag.id"
-          size="x-small"
+          size="small"
           :variant="isSelected(tag.name) ? 'flat' : 'outlined'"
           :color="isSelected(tag.name) ? 'primary' : undefined"
           @click.stop.prevent="emit('select-tag', tag.name)"
@@ -41,9 +41,9 @@ const formattedDate = useDateFormat(
     </v-card-text>
 
     <v-card-subtitle
-      class="text-sm text-gray-500 d-flex align-center justify-space-between mt-2"
+      class="d-flex align-center justify-space-between mt-2"
     >
-      <span>{{ formattedDate }}</span>
+      <span class="text-caption text-medium-emphasis">{{ formattedDate }}</span>
 
       <div class="d-flex align-center">
         <v-icon
@@ -52,7 +52,7 @@ const formattedDate = useDateFormat(
           color="red"
           class="me-1"
         />
-        <span>{{ article.likes_count ?? 0 }}</span>
+        <span class="text-caption">{{ article.likes_count ?? 0 }}</span>
       </div>
     </v-card-subtitle>
   </v-card>

--- a/app/src/features/articles/ArticleCard.vue
+++ b/app/src/features/articles/ArticleCard.vue
@@ -40,9 +40,7 @@ const formattedDate = useDateFormat(
       </div>
     </v-card-text>
 
-    <v-card-subtitle
-      class="d-flex align-center justify-space-between mt-2"
-    >
+    <v-card-subtitle class="d-flex align-center justify-space-between mt-2">
       <span class="text-caption text-medium-emphasis">{{ formattedDate }}</span>
 
       <div class="d-flex align-center">

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -103,9 +103,9 @@ watch(
 
 <template>
   <v-sheet color="grey-lighten-4" min-height="100%">
-    <v-container class="py-12">
+    <v-container class="py-8">
       <v-row justify="center">
-        <v-col cols="12" md="8" lg="7">
+        <v-col cols="12" sm="10">
           <div v-if="loading" class="d-flex justify-center py-12">
             <v-progress-circular indeterminate color="primary" />
           </div>
@@ -128,36 +128,14 @@ watch(
                 variant="flat"
                 label
               >
-                <v-icon start icon="mdi-tag-outline" size="x-small" />
+                <v-icon start icon="mdi-tag-outline" size="small" />
                 {{ tag.name }}
               </v-chip>
             </div>
 
-            <div
-              class="text-body-2 text-medium-emphasis mb-6 d-flex align-center"
-            >
-              <div>
-                <div>著者 {{ article.author?.name }}</div>
-                <div>投稿日 {{ formattedDate }}</div>
-              </div>
-
-              <v-spacer />
-
-              <div class="d-flex align-center">
-                <v-btn
-                  variant="text"
-                  icon
-                  color="red"
-                  :loading="likeSubmitting"
-                  @click="likeArticle"
-                >
-                  <v-icon :icon="isLiked ? 'mdi-heart' : 'mdi-heart-outline'" />
-                </v-btn>
-
-                <span class="text-subtitle-1 ml-1">
-                  {{ article.likes_count ?? 0 }}
-                </span>
-              </div>
+            <div class="text-body-2 text-medium-emphasis mb-6">
+              <div>著者 {{ article.author?.name }}</div>
+              <div>投稿日 {{ formattedDate }}</div>
             </div>
 
             <v-alert v-if="likeError" type="error" class="mb-4">
@@ -170,6 +148,23 @@ watch(
                 :source="article.content ?? ''"
               />
             </v-card>
+
+            <div class="d-flex align-center ga-3 my-6">
+              <v-btn
+                variant="text"
+                :color="isLiked ? 'red' : undefined"
+                size="large"
+                :loading="likeSubmitting"
+                @click="likeArticle"
+              >
+                <v-icon
+                  :icon="isLiked ? 'mdi-heart' : 'mdi-heart-outline'"
+                  size="large"
+                  start
+                />
+                {{ article.likes_count ?? 0 }}
+              </v-btn>
+            </div>
 
             <div class="mt-10">
               <ReplySection :article-id="article.id" />

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -5,9 +5,13 @@ import ArticleCard from './ArticleCard.vue'
 import type { ServerArticleJSONResponse } from '@/api/generated/apiSchema'
 import { api } from '@/api/client'
 import { useArticleNotificationStore } from '@/stores/articleNotification'
+import { useAuthStore } from '@/stores/auth'
 
 const route = useRoute()
 const router = useRouter()
+
+const router = useRouter()
+const auth = useAuthStore()
 
 const articles = ref<ServerArticleJSONResponse[]>([])
 const loading = ref(false)
@@ -91,7 +95,20 @@ watch(selectedTags, () => void fetchArticles(), { immediate: true })
 <template>
   <v-container class="py-8">
     <v-row justify="center">
-      <v-col cols="12" md="8" lg="6">
+      <v-col cols="12" sm="10">
+        <div class="d-flex align-center mb-4">
+          <h1 class="text-h4 font-weight-bold">記事一覧</h1>
+          <v-spacer />
+          <v-btn
+            v-if="auth.isAuthenticated"
+            color="primary"
+            prepend-icon="mdi-plus"
+            @click="router.push('/articles/new')"
+          >
+            新規作成
+          </v-btn>
+        </div>
+
         <v-alert
           v-if="showCreatedAlert"
           type="success"

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -10,7 +10,6 @@ import { useAuthStore } from '@/stores/auth'
 const route = useRoute()
 const router = useRouter()
 
-const router = useRouter()
 const auth = useAuthStore()
 
 const articles = ref<ServerArticleJSONResponse[]>([])

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -102,7 +102,7 @@ watch(selectedTags, () => void fetchArticles(), { immediate: true })
             v-if="auth.isAuthenticated"
             color="primary"
             prepend-icon="mdi-plus"
-            @click="router.push('/articles/new')"
+            to="/articles/new"
           >
             新規作成
           </v-btn>

--- a/app/src/features/auth/LoginView.vue
+++ b/app/src/features/auth/LoginView.vue
@@ -40,7 +40,7 @@ const onSubmit = async () => {
 </script>
 
 <template>
-  <v-container class="fill-height bg-grey-lighten-4" fluid>
+  <v-container class="py-8">
     <v-row justify="center" align="center">
       <v-col cols="12" sm="8" md="6" lg="4">
         <v-card class="pa-6">

--- a/app/src/features/errors/ErrorStatusView.vue
+++ b/app/src/features/errors/ErrorStatusView.vue
@@ -11,86 +11,36 @@ const router = useRouter()
 </script>
 
 <template>
-  <v-container class="error-status py-12" fluid>
-    <div class="error-status__content">
-      <p class="error-status__code">{{ statusCode }}</p>
-      <h1 class="error-status__title">{{ title }}</h1>
-      <p class="error-status__message">{{ message }}</p>
+  <v-container class="fill-height">
+    <v-row justify="center" align="center">
+      <v-col cols="12" sm="10" class="text-center">
+        <p class="text-caption font-weight-bold text-primary mb-3">
+          {{ statusCode }}
+        </p>
+        <h1 class="text-h3 font-weight-bold mb-4">{{ title }}</h1>
+        <p class="text-body-1 text-medium-emphasis mb-8 mx-auto" style="max-width: 36rem">
+          {{ message }}
+        </p>
 
-      <div class="error-status__actions">
-        <v-btn
-          color="primary"
-          size="large"
-          prepend-icon="mdi-home"
-          @click="router.push('/')"
-        >
-          ホームへ戻る
-        </v-btn>
-        <v-btn
-          variant="outlined"
-          size="large"
-          prepend-icon="mdi-refresh"
-          @click="router.go(0)"
-        >
-          再読み込み
-        </v-btn>
-      </div>
-    </div>
+        <div class="d-flex justify-center ga-3">
+          <v-btn
+            color="primary"
+            size="large"
+            prepend-icon="mdi-home"
+            @click="router.push('/')"
+          >
+            ホームへ戻る
+          </v-btn>
+          <v-btn
+            variant="outlined"
+            size="large"
+            prepend-icon="mdi-refresh"
+            @click="router.go(0)"
+          >
+            再読み込み
+          </v-btn>
+        </div>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
-
-<style scoped>
-.error-status {
-  min-height: calc(100vh - 64px);
-  display: grid;
-  place-items: center;
-}
-
-.error-status__content {
-  width: min(100%, 560px);
-  text-align: center;
-  padding: 32px 20px;
-}
-
-.error-status__code {
-  margin: 0 0 12px;
-  color: rgb(var(--v-theme-primary));
-  font-size: 0.875rem;
-  font-weight: 700;
-}
-
-.error-status__title {
-  margin: 0;
-  font-size: 2rem;
-  line-height: 1.2;
-  font-weight: 700;
-}
-
-.error-status__message {
-  margin: 16px auto 0;
-  max-width: 36rem;
-  color: rgba(var(--v-theme-on-surface), 0.72);
-  font-size: 1rem;
-  line-height: 1.8;
-}
-
-.error-status__actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 12px;
-  margin-top: 32px;
-}
-
-@media (min-width: 600px) {
-  .error-status__title {
-    font-size: 2.5rem;
-  }
-}
-
-@media (min-width: 960px) {
-  .error-status__title {
-    font-size: 3rem;
-  }
-}
-</style>

--- a/app/src/features/errors/ErrorStatusView.vue
+++ b/app/src/features/errors/ErrorStatusView.vue
@@ -18,7 +18,10 @@ const router = useRouter()
           {{ statusCode }}
         </p>
         <h1 class="text-h3 font-weight-bold mb-4">{{ title }}</h1>
-        <p class="text-body-1 text-medium-emphasis mb-8 mx-auto" style="max-width: 36rem">
+        <p
+          class="text-body-1 text-medium-emphasis mb-8 mx-auto"
+          style="max-width: 36rem"
+        >
           {{ message }}
         </p>
 

--- a/app/src/features/home/HomeView.vue
+++ b/app/src/features/home/HomeView.vue
@@ -3,11 +3,11 @@
 </script>
 
 <template>
-  <main>
-    <h1>ホーム</h1>
-  </main>
+  <v-container class="py-8">
+    <v-row justify="center">
+      <v-col cols="12" sm="10">
+        <h1 class="text-h4 font-weight-bold">ホーム</h1>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
-
-<style scoped>
-/* scoped: このコンポーネント内だけに効くCSS */
-</style>

--- a/app/src/features/replies/ReplyItem.vue
+++ b/app/src/features/replies/ReplyItem.vue
@@ -132,7 +132,7 @@ const formattedDate = useTimeAgo(() => props.reply.created_at, {
       <span class="text-body-2 font-weight-medium">
         {{ reply.user_name }}
       </span>
-      <span class="text-caption text-medium-emphasis">
+      <span class="text-body-2 text-medium-emphasis">
         {{ formattedDate }}
       </span>
     </div>

--- a/app/src/features/replies/ReplyThread.vue
+++ b/app/src/features/replies/ReplyThread.vue
@@ -88,7 +88,7 @@ const handleBestUpdated = (replyId: number, isBest: boolean) => {
       @best-updated="handleBestUpdated"
     />
 
-    <div v-if="showReplyForm" class="ml-8">
+    <div v-if="showReplyForm" class="ms-8">
       <ReplyForm
         :article-id="articleId"
         :parent-id="reply.id"
@@ -98,7 +98,7 @@ const handleBestUpdated = (replyId: number, isBest: boolean) => {
       />
     </div>
 
-    <div v-if="children.length > 0" class="ml-8">
+    <div v-if="children.length > 0" class="ms-8">
       <div
         v-if="visibleChildren.length > 0"
         class="d-flex flex-column ga-3 mb-2"

--- a/app/src/features/settings/PasswordChangeView.vue
+++ b/app/src/features/settings/PasswordChangeView.vue
@@ -68,7 +68,7 @@ const onSubmit = async () => {
 </script>
 
 <template>
-  <v-container class="fill-height bg-grey-lighten-4" fluid>
+  <v-container class="py-8">
     <v-row justify="center" align="center">
       <v-col cols="12" sm="8" md="6" lg="4">
         <v-card class="pa-6">

--- a/app/src/features/settings/ProfileView.vue
+++ b/app/src/features/settings/ProfileView.vue
@@ -65,7 +65,7 @@ const saveBio = async () => {
 <template>
   <v-container class="py-8">
     <v-row justify="center">
-      <v-col cols="12" md="8" lg="6">
+      <v-col cols="12" sm="10">
         <v-alert
           v-if="error"
           type="error"


### PR DESCRIPTION
## やったこと
- ロゴクリック遷移の追加
- 全画面の `v-col` を `cols="12" sm="10"` に統一
- 認証系（Login / PasswordChange）のみカード形式のため `sm="8" md="6" lg="4"` を維持
- Login / PasswordChange の `fill-height bg-grey-lighten-4` → `py-8` に統一
- いいねボタンを記事本文直下に移動
- タグフォントサイズ改善（chip `x-small`→`small`, 日付 `text-caption`→`text-body-2`）
- ErrorStatusView の生CSS全削除（42行）→ Vuetify `fill-height` のみに
- ArticleCard の Tailwind クラス撤去 → Vuetify クラスに置換
- 記事一覧に新規作成ボタン追加（`/articles/new` 導線）


## 動作確認
<img width="1918" height="915" alt="image" src="https://github.com/user-attachments/assets/1d569bab-4149-4eab-8f54-ab0c27c679c7" />


記事一覧にロゴをクリックしたら遷移

https://github.com/user-attachments/assets/c13d0811-1cc2-4aa7-a867-5d82e8f1257a




Closes #239