### PR TITLE
ログイン時にアラート機能の追加

### DIFF
--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -45,7 +45,11 @@ api.instance.interceptors.response.use(
       if (!skip) {
         const status = error.response?.status ?? null
 
-        if (status === 404 || (status !== null && status >= 500)) {
+        if (
+          status === 401 ||
+          status === 404 ||
+          (status !== null && status >= 500)
+        ) {
           apiErrorHandler?.(status)
         }
 

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -62,8 +62,6 @@ const likeArticle = async () => {
     }
 
     if (axios.isAxiosError(err) && err.response?.status === 401) {
-      auth.clearToken()
-      await router.push({ path: '/login', query: { redirect: route.fullPath } })
       return
     }
 

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -17,7 +17,10 @@ const loading = ref(false)
 const error = ref<string | null>(null)
 
 const showCreatedAlert = ref(false)
+const showLoginAlert = ref(false)
 const notificationStore = useArticleNotificationStore()
+const authStore = useAuthStore()
+const authNotificationStore = useAuthNotificationStore()
 
 // URL の ?tag=... を唯一の真実として selectedTags を扱う。
 // リロード / ブックマーク / 共有リンクで絞り込み状態を再現できるようにするため、
@@ -84,6 +87,9 @@ onMounted(() => {
   if (notificationStore.consumeCreated()) {
     showCreatedAlert.value = true
   }
+  if (authNotificationStore.consumeLoggedIn()) {
+    showLoginAlert.value = true
+  }
   void fetchTagCandidates()
 })
 
@@ -107,6 +113,16 @@ watch(selectedTags, () => void fetchArticles(), { immediate: true })
             新規作成
           </v-btn>
         </div>
+
+        <v-alert
+          v-if="showLoginAlert"
+          type="success"
+          class="mb-4"
+          closable
+          @click:close="showLoginAlert = false"
+        >
+          ようこそ、{{ authStore.user?.name }} さん
+        </v-alert>
 
         <v-alert
           v-if="showCreatedAlert"

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -121,7 +121,11 @@ watch(selectedTags, () => void fetchArticles(), { immediate: true })
           closable
           @click:close="showLoginAlert = false"
         >
-          ようこそ、{{ authStore.user?.name }} さん
+          {{
+            authStore.user?.name
+              ? `ようこそ、${authStore.user.name} さん`
+              : 'ログインしました'
+          }}
         </v-alert>
 
         <v-alert

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -11,8 +11,6 @@ import { useAuthStore } from '@/stores/auth'
 const route = useRoute()
 const router = useRouter()
 
-const auth = useAuthStore()
-
 const articles = ref<ServerArticleJSONResponse[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
@@ -106,7 +104,7 @@ watch(selectedTags, () => void fetchArticles(), { immediate: true })
           <h1 class="text-h4 font-weight-bold">記事一覧</h1>
           <v-spacer />
           <v-btn
-            v-if="auth.isAuthenticated"
+            v-if="authStore.isAuthenticated"
             color="primary"
             prepend-icon="mdi-plus"
             to="/articles/new"

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -115,6 +115,16 @@ watch(selectedTags, () => void fetchArticles(), { immediate: true })
         </div>
 
         <v-alert
+          v-if="showCreatedAlert"
+          type="success"
+          class="mb-4"
+          closable
+          @click:close="showCreatedAlert = false"
+        >
+          記事を投稿しました
+        </v-alert>
+
+        <v-alert
           v-if="showLoginAlert"
           type="success"
           class="mb-4"
@@ -126,16 +136,6 @@ watch(selectedTags, () => void fetchArticles(), { immediate: true })
               ? `ようこそ、${authStore.user.name} さん`
               : 'ログインしました'
           }}
-        </v-alert>
-
-        <v-alert
-          v-if="showCreatedAlert"
-          type="success"
-          class="mb-4"
-          closable
-          @click:close="showCreatedAlert = false"
-        >
-          記事を投稿しました
         </v-alert>
 
         <v-select

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -88,7 +88,10 @@ onMounted(() => {
   if (notificationStore.consumeCreated()) {
     showCreatedAlert.value = true
   }
-  if (authNotificationStore.consumeLoggedIn()) {
+  if (
+    authNotificationStore.consumeLoggedIn() &&
+    authStore.isAuthenticated
+  ) {
     showLoginAlert.value = true
   }
   void fetchTagCandidates()
@@ -134,7 +137,7 @@ watch(selectedTags, () => void fetchArticles(), { immediate: true })
         >
           {{
             authStore.user?.name
-              ? `ようこそ、${authStore.user.name} さん`
+              ? `ようこそ、${authStore.user.name}さん`
               : 'ログインしました'
           }}
         </v-alert>

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -88,10 +88,7 @@ onMounted(() => {
   if (notificationStore.consumeCreated()) {
     showCreatedAlert.value = true
   }
-  if (
-    authNotificationStore.consumeLoggedIn() &&
-    authStore.isAuthenticated
-  ) {
+  if (authNotificationStore.consumeLoggedIn() && authStore.isAuthenticated) {
     showLoginAlert.value = true
   }
   void fetchTagCandidates()

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -5,6 +5,7 @@ import ArticleCard from './ArticleCard.vue'
 import type { ServerArticleJSONResponse } from '@/api/generated/apiSchema'
 import { api } from '@/api/client'
 import { useArticleNotificationStore } from '@/stores/articleNotification'
+import { useAuthNotificationStore } from '@/stores/authNotification'
 import { useAuthStore } from '@/stores/auth'
 
 const route = useRoute()

--- a/app/src/features/auth/LoginView.vue
+++ b/app/src/features/auth/LoginView.vue
@@ -21,7 +21,15 @@ const onSubmit = async () => {
   errorMessage.value = null
   try {
     await auth.login(name.value, password.value)
-    await auth.fetchMe()
+
+    try {
+      await auth.fetchMe()
+    } catch (e) {
+      // ログイン自体は成功しているため、ユーザー情報取得失敗は
+      // ログイン失敗として扱わず、遷移を継続する
+      console.error('Failed to fetch user info after login:', e)
+    }
+
     authNotification.markLoggedIn()
 
     const redirect =

--- a/app/src/features/auth/LoginView.vue
+++ b/app/src/features/auth/LoginView.vue
@@ -23,7 +23,7 @@ const onSubmit = async () => {
     await auth.login(name.value, password.value)
 
     try {
-      await auth.fetchMe()
+      await auth.fetchMe({ skipGlobalErrorHandler: true })
     } catch (e) {
       // ログイン自体は成功しているため、ユーザー情報取得失敗は
       // ログイン失敗として扱わず、遷移を継続する

--- a/app/src/features/auth/LoginView.vue
+++ b/app/src/features/auth/LoginView.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
+import { useAuthNotificationStore } from '@/stores/authNotification'
 
 const name = ref('')
 const password = ref('')
@@ -12,6 +13,7 @@ const errorMessage = ref<string | null>(null)
 const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
+const authNotification = useAuthNotificationStore()
 
 const onSubmit = async () => {
   if (submitting.value) return
@@ -19,6 +21,9 @@ const onSubmit = async () => {
   errorMessage.value = null
   try {
     await auth.login(name.value, password.value)
+    await auth.fetchMe()
+    authNotification.markLoggedIn()
+
     const redirect =
       typeof route.query.redirect === 'string'
         ? route.query.redirect

--- a/app/src/features/auth/LoginView.vue
+++ b/app/src/features/auth/LoginView.vue
@@ -25,8 +25,13 @@ const onSubmit = async () => {
     try {
       await auth.fetchMe({ skipGlobalErrorHandler: true })
     } catch (e) {
-      // ログイン自体は成功しているため、ユーザー情報取得失敗は
-      // ログイン失敗として扱わず、遷移を継続する
+      // 401 (Unauthorized) の場合はトークンをクリアしてログイン失敗として扱う
+      if (axios.isAxiosError(e) && e.response?.status === 401) {
+        auth.clearToken()
+        throw e
+      }
+      // それ以外のエラー（500や通信断など）は、ログイン自体は成功しているため
+      // 遷移を継続させるが、エラー内容はログに出力する
       console.error('Failed to fetch user info after login:', e)
     }
 

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -82,6 +82,21 @@ const router = createRouter({
 })
 
 setApiErrorHandler((status) => {
+  if (status === 401) {
+    const auth = useAuthStore()
+    auth.clearToken()
+
+    const current = router.currentRoute.value
+    if (current.path === '/login') {
+      return
+    }
+
+    void router
+      .push({ path: '/login', query: { redirect: current.fullPath } })
+      .catch(() => undefined)
+    return
+  }
+
   const name = status === 404 ? 'not-found' : 'server-error'
 
   if (router.currentRoute.value.name === name) {

--- a/app/src/stores/auth.ts
+++ b/app/src/stores/auth.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { api, AUTH_TOKEN_STORAGE_KEY } from '@/api/client'
 import type { ServerMeResponse } from '@/api/generated/apiSchema'
+import { useAuthNotificationStore } from './authNotification'
 
 export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(localStorage.getItem(AUTH_TOKEN_STORAGE_KEY))
@@ -18,6 +19,10 @@ export const useAuthStore = defineStore('auth', () => {
     token.value = null
     user.value = null
     localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY)
+
+    // 通知フラグもリセットして、再ログイン時や未ログイン時の誤表示を防ぐ
+    const authNotification = useAuthNotificationStore()
+    authNotification.consumeLoggedIn()
   }
 
   const login = async (name: string, password: string) => {

--- a/app/src/stores/auth.ts
+++ b/app/src/stores/auth.ts
@@ -31,9 +31,9 @@ export const useAuthStore = defineStore('auth', () => {
     setToken(data.token)
   }
 
-  const fetchMe = async () => {
+  const fetchMe = async (options?: { skipGlobalErrorHandler?: boolean }) => {
     try {
-      const { data } = await api.api.authMeList()
+      const { data } = await api.api.authMeList(options)
       user.value = data
     } catch (e) {
       user.value = null

--- a/app/src/stores/auth.ts
+++ b/app/src/stores/auth.ts
@@ -21,7 +21,10 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   const login = async (name: string, password: string) => {
-    const { data } = await api.api.authLoginCreate({ name, password })
+    const { data } = await api.api.authLoginCreate(
+      { name, password },
+      { skipGlobalErrorHandler: true },
+    )
     if (!data.token) {
       throw new Error('トークンが返却されませんでした')
     }

--- a/app/src/stores/auth.ts
+++ b/app/src/stores/auth.ts
@@ -1,9 +1,11 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { api, AUTH_TOKEN_STORAGE_KEY } from '@/api/client'
+import type { ServerMeResponse } from '@/api/generated/apiSchema'
 
 export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(localStorage.getItem(AUTH_TOKEN_STORAGE_KEY))
+  const user = ref<ServerMeResponse | null>(null)
 
   const isAuthenticated = computed(() => token.value !== null)
 
@@ -14,6 +16,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   const clearToken = () => {
     token.value = null
+    user.value = null
     localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY)
   }
 
@@ -25,10 +28,22 @@ export const useAuthStore = defineStore('auth', () => {
     setToken(data.token)
   }
 
+  const fetchMe = async () => {
+    try {
+      const { data } = await api.api.authMeList()
+      user.value = data
+    } catch (e) {
+      user.value = null
+      throw e
+    }
+  }
+
   return {
     token,
+    user,
     isAuthenticated,
     login,
+    fetchMe,
     clearToken,
   }
 })

--- a/app/src/stores/authNotification.ts
+++ b/app/src/stores/authNotification.ts
@@ -1,0 +1,18 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+export const useAuthNotificationStore = defineStore('authNotification', () => {
+  const loggedIn = ref(false)
+
+  const markLoggedIn = () => {
+    loggedIn.value = true
+  }
+
+  const consumeLoggedIn = () => {
+    if (!loggedIn.value) return false
+    loggedIn.value = false
+    return true
+  }
+
+  return { loggedIn, markLoggedIn, consumeLoggedIn }
+})


### PR DESCRIPTION
# 概要

  ログイン成功時に「ようこそ、〇〇さん」というウェルカムアラートを表示する機能を追加しました。
  ユーザーがログインに成功したことを即座に認識でき、パーソナライズされた体験を提供することを目的としています。

  ---

# 変更内容

## 状態管理の追加
   - auth ストアの拡張
     - user ステートを追加し、ログインユーザー情報を保持
     - fetchMe メソッドを実装し、/api/auth/me からユーザー情報を取得
   - authNotification ストアの新規作成
     - loggedIn フラグを追加し、ログイン直後の状態を管理
     - markLoggedIn / consumeLoggedIn メソッドにより、通知の「予約」と「消費」を制御

## ロジックの実装
   - ログインフローの更新 (LoginView.vue)
     - 認証成功後、即座に fetchMe を実行してユーザー情報を同期
     - authNotification.markLoggedIn() を呼び出し、遷移先でのアラート表示を予約

## UIの追加・更新
   - アラート表示 (ArticlesView.vue)
     - v-alert (type="success") を使用したウェルカムメッセージの実装
     - マウント時に通知フラグを確認し、表示後にフラグをリセットする制御を追加
     - 既存の「記事投稿完了アラート」と同様のデザイン・位置に配置し、UIの一貫性を保持

   - 永続性と一貫性: 既存の articleNotification (記事投稿通知) と同じ設計パターンを採用することで、開発者にとって理解しやすく、メンテナンス性の高い構造にしました。
   - ユーザー情報の確実な取得: ログイン直後に情報をフェッチすることで、遷移後のアラートで即座にユーザー名を表示できるようにしました。
   - 副作用の防止: アラート表示フラグを consumeLoggedIn で消費する形式にすることで、リロード時などに重複してアラートが表示されるのを防いでいます。

  ---

# 影響範囲

   - app/src/stores/auth.ts（ユーザー情報の保持）
   - app/src/features/auth/LoginView.vue（ログイン処理）
   - app/src/features/articles/ArticlesView.vue（アラート表示UI）

  ---

 ## 補足

   - ログイン後のリダイレクト先が /articles 以外の場合でも、次に /articles を訪れた際にアラートが表示される仕様です。
   - Vuetify の closable 属性により、ユーザーが任意でアラートを閉じることが可能です。

  ---

 # 動作確認

   - [x] 正しい資格情報でログイン後、/articles に遷移して「ようこそ、〇〇さん」と表示される
   - [x] 表示されたユーザー名が、ログインしたユーザーの名前と一致している
   - [x] アラートの「×」ボタンで正常に閉じることができる
   - [x] 一度表示された後、ページをリロードしても再表示されない
   - [x] ログインに失敗した場合は、アラートが表示されない
   - [x] ログアウト後に再度ログインしても、正しく動作する

  ---

# 動作確認「写真」

<img width="1919" height="1128" alt="スクリーンショット 2026-05-22 094950" src="https://github.com/user-attachments/assets/8d6cf0d4-3877-486d-80ac-af48ad06461f" />

  ---

Close #88