### PR TITLE
プロフィール画面リニューアル（他人プロフィール閲覧・投稿/いいねタブ）

### DIFF
--- a/api/internal/article/handler/get_list_articles.go
+++ b/api/internal/article/handler/get_list_articles.go
@@ -82,7 +82,7 @@ func (h *Handler) ListArticles(ctx context.Context, userID int64, tagNames []str
 		return ListArticlesJSONResponse{}, err
 	}
 
-	return newListArticlesJSONResponse(articles), nil
+	return NewListArticlesJSONResponse(articles), nil
 }
 
 // normalizeFilterTagNames は ?tag=... のクエリパラメータを SQL の LOWER(t.name) 比較に揃える。
@@ -109,7 +109,7 @@ func normalizeFilterTagNames(raw []string) ([]string, error) {
 	return normalized, nil
 }
 
-func newListArticlesJSONResponse(articles []article.Article) ListArticlesJSONResponse {
+func NewListArticlesJSONResponse(articles []article.Article) ListArticlesJSONResponse {
 	response := ListArticlesJSONResponse{
 		Articles: make([]ArticleListItemJSON, 0, len(articles)),
 	}

--- a/api/internal/article/repository/get_list_articles.go
+++ b/api/internal/article/repository/get_list_articles.go
@@ -2,42 +2,48 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 
 	"github.com/Baymax6s/KOBE-Tech/api/internal/article"
 	"github.com/lib/pq"
 )
 
+// articleListSelectFrom は記事一覧系クエリで共通の SELECT/FROM 句。
+// $1 は閲覧者(viewer)の user_id で、liked_by_me の判定に使う。
+// WHERE / JOIN / ORDER は呼び出し側が用途に応じて後置する。
+const articleListSelectFrom = `
+	SELECT
+		a.id,
+		a.title,
+		a.content,
+		a.user_id,
+		a.created_at,
+		a.updated_at,
+		COALESCE(l.like_count, 0),
+		COALESCE(tag_summary.tag_ids, ARRAY[]::integer[]),
+		COALESCE(tag_summary.tag_names, ARRAY[]::text[]),
+		EXISTS(SELECT 1 FROM likes WHERE article_id = a.id AND user_id = $1)
+	FROM articles a
+	LEFT JOIN (
+		SELECT article_id, COUNT(*) AS like_count FROM likes GROUP BY article_id
+	) l ON l.article_id = a.id
+	LEFT JOIN (
+		SELECT
+			article_tag.article_id,
+			array_agg(t.id ORDER BY t.name, t.id) AS tag_ids,
+			array_agg(t.name::text ORDER BY t.name, t.id) AS tag_names
+		FROM article_tags article_tag
+		JOIN tags t ON t.id = article_tag.tag_id
+		GROUP BY article_tag.article_id
+	) tag_summary ON tag_summary.article_id = a.id
+`
+
 func (r *Repository) ListArticles(ctx context.Context, userID int64, tagNames []string) ([]article.Article, error) {
 	if r == nil || r.db == nil {
 		return nil, errors.New("article repository is not configured")
 	}
-	query := `
-		SELECT
-			a.id,
-			a.title,
-			a.content,
-			a.user_id,
-			a.created_at,
-			a.updated_at,
-			COALESCE(l.like_count, 0),
-			COALESCE(tag_summary.tag_ids, ARRAY[]::integer[]),
-			COALESCE(tag_summary.tag_names, ARRAY[]::text[]),
-			EXISTS(SELECT 1 FROM likes WHERE article_id = a.id AND user_id = $1)
-		FROM articles a
-		LEFT JOIN (
-			SELECT article_id, COUNT(*) AS like_count FROM likes GROUP BY article_id
-		) l ON l.article_id = a.id
-		LEFT JOIN (
-			SELECT
-				article_tag.article_id,
-				array_agg(t.id ORDER BY t.name, t.id) AS tag_ids,
-				array_agg(t.name::text ORDER BY t.name, t.id) AS tag_names
-			FROM article_tags article_tag
-			JOIN tags t ON t.id = article_tag.tag_id
-			GROUP BY article_tag.article_id
-		) tag_summary ON tag_summary.article_id = a.id
-	`
+	query := articleListSelectFrom
 
 	args := []any{userID}
 	if len(tagNames) > 0 {
@@ -64,6 +70,12 @@ func (r *Repository) ListArticles(ctx context.Context, userID int64, tagNames []
 	}
 	defer rows.Close()
 
+	return scanArticleList(rows)
+}
+
+// scanArticleList は articleListSelectFrom の列順に従って記事一覧を読み出す。
+// 列の並びと一致させる責務をこの 1 箇所に集約し、一覧系クエリ間で共有する。
+func scanArticleList(rows *sql.Rows) ([]article.Article, error) {
 	articles := make([]article.Article, 0)
 	for rows.Next() {
 		var item article.Article

--- a/api/internal/article/repository/list_profile_articles.go
+++ b/api/internal/article/repository/list_profile_articles.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Baymax6s/KOBE-Tech/api/internal/article"
+)
+
+// ListArticlesByAuthor は authorID が投稿した記事を新しい順に返す。
+// viewerID は閲覧者で、各記事の liked_by_me 判定に使う（authorID とは別概念）。
+func (r *Repository) ListArticlesByAuthor(ctx context.Context, authorID int64, viewerID int64) ([]article.Article, error) {
+	if r == nil || r.db == nil {
+		return nil, errors.New("article repository is not configured")
+	}
+
+	query := articleListSelectFrom + `
+		WHERE a.user_id = $2
+		ORDER BY a.created_at DESC, a.id DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, viewerID, authorID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanArticleList(rows)
+}
+
+// ListLikedArticles は likerID がいいねした記事を「いいねした順」で返す。
+// viewerID は閲覧者で、各記事の liked_by_me 判定に使う（likerID とは別概念）。
+func (r *Repository) ListLikedArticles(ctx context.Context, likerID int64, viewerID int64) ([]article.Article, error) {
+	if r == nil || r.db == nil {
+		return nil, errors.New("article repository is not configured")
+	}
+
+	query := articleListSelectFrom + `
+		JOIN likes liker_like
+			ON liker_like.article_id = a.id AND liker_like.user_id = $2
+		ORDER BY liker_like.created_at DESC, a.id DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, viewerID, likerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanArticleList(rows)
+}

--- a/api/internal/profile/handler/get_user_articles.go
+++ b/api/internal/profile/handler/get_user_articles.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+
+	articlehandler "github.com/Baymax6s/KOBE-Tech/api/internal/article/handler"
+	"github.com/Baymax6s/KOBE-Tech/api/internal/auth"
+	"github.com/gin-gonic/gin"
+)
+
+// getUserArticlesHandler godoc
+//
+//	@Summary		List articles posted by a user
+//	@Description	指定ユーザーが投稿した記事一覧を新しい順に取得する
+//	@Tags			profile
+//	@Produce		json
+//	@Param			user_id	path		int	true	"User ID"
+//	@Success		200		{object}	handler.ListArticlesJSONResponse
+//	@Failure		400		{object}	ErrorResponse
+//	@Failure		500		{object}	ErrorResponse
+//	@Router			/api/profile/{user_id}/articles [get]
+func (h *Handler) getUserArticlesHandler(c *gin.Context) {
+	userID, err := strconv.ParseInt(c.Param("user_id"), 10, 64)
+	if err != nil || userID <= 0 {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Message: "invalid user_id"})
+		return
+	}
+
+	viewerID, _ := auth.OptionalUserID(c)
+
+	articles, err := h.articleRepo.ListArticlesByAuthor(c.Request.Context(), userID, viewerID)
+	if err != nil {
+		log.Printf("list user articles: %v", err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Message: "failed to list articles"})
+		return
+	}
+
+	c.JSON(http.StatusOK, articlehandler.NewListArticlesJSONResponse(articles))
+}
+
+// getUserLikedArticlesHandler godoc
+//
+//	@Summary		List articles liked by a user
+//	@Description	指定ユーザーがいいねした記事一覧をいいねした順に取得する
+//	@Tags			profile
+//	@Produce		json
+//	@Param			user_id	path		int	true	"User ID"
+//	@Success		200		{object}	handler.ListArticlesJSONResponse
+//	@Failure		400		{object}	ErrorResponse
+//	@Failure		500		{object}	ErrorResponse
+//	@Router			/api/profile/{user_id}/liked-articles [get]
+func (h *Handler) getUserLikedArticlesHandler(c *gin.Context) {
+	userID, err := strconv.ParseInt(c.Param("user_id"), 10, 64)
+	if err != nil || userID <= 0 {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Message: "invalid user_id"})
+		return
+	}
+
+	viewerID, _ := auth.OptionalUserID(c)
+
+	articles, err := h.articleRepo.ListLikedArticles(c.Request.Context(), userID, viewerID)
+	if err != nil {
+		log.Printf("list user liked articles: %v", err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Message: "failed to list liked articles"})
+		return
+	}
+
+	c.JSON(http.StatusOK, articlehandler.NewListArticlesJSONResponse(articles))
+}

--- a/api/internal/profile/handler/get_user_profile.go
+++ b/api/internal/profile/handler/get_user_profile.go
@@ -3,11 +3,14 @@ package handler
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
 	"github.com/Baymax6s/KOBE-Tech/api/internal/auth"
+	"github.com/Baymax6s/KOBE-Tech/api/internal/minio"
 	"github.com/Baymax6s/KOBE-Tech/api/internal/profile"
 	"github.com/Baymax6s/KOBE-Tech/api/internal/profile/repository"
 	"github.com/gin-gonic/gin"
@@ -17,6 +20,7 @@ type ProfileJSON struct {
 	ID               int64      `json:"id"`
 	Name             string     `json:"name"`
 	Bio              string     `json:"bio"`
+	AvatarURL        string     `json:"avatar_url"`
 	ProfileCreatedAt *time.Time `json:"profile_created_at"`
 	ProfileUpdatedAt *time.Time `json:"profile_updated_at"`
 	IsOwner          bool       `json:"is_owner"`
@@ -69,10 +73,33 @@ func (h *Handler) GetProfile(ctx context.Context, targetUserID int64, currentUse
 		return ProfileJSON{}, err
 	}
 	isOwner := currentUserID != 0 && currentUserID == targetUserID
-	return newProfileJSON(p, isOwner), nil
+	return newProfileJSON(p, isOwner, resolveAvatarURL(ctx, p)), nil
 }
 
-func newProfileJSON(p profile.Profile, isOwner bool) ProfileJSON {
+// resolveAvatarURL はアバターがアップロード済みのときだけ presigned GET URL を返す。
+// ストレージ接続や署名に失敗してもプロフィール取得自体は止めず、空文字を返して
+// フロント側のフォールバック表示（既定アイコン）に委ねる。
+func resolveAvatarURL(ctx context.Context, p profile.Profile) string {
+	if !p.UserProfile.IsUploaded || !p.UserProfile.ObjectKey.Valid || p.UserProfile.ObjectKey.String == "" {
+		return ""
+	}
+
+	client, err := minio.NewClient()
+	if err != nil {
+		log.Printf("avatar url: connect storage: %v", err)
+		return ""
+	}
+
+	url, err := minio.GeneratePresignedGetURL(ctx, client, os.Getenv("MINIO_BUCKET_NAME"), p.UserProfile.ObjectKey.String)
+	if err != nil {
+		log.Printf("avatar url: presign: %v", err)
+		return ""
+	}
+
+	return url
+}
+
+func newProfileJSON(p profile.Profile, isOwner bool, avatarURL string) ProfileJSON {
 	var profileCreatedAt *time.Time
 	if p.UserProfile.CreatedAt.Valid {
 		t := p.UserProfile.CreatedAt.Time
@@ -89,6 +116,7 @@ func newProfileJSON(p profile.Profile, isOwner bool) ProfileJSON {
 		ID:               p.User.ID,
 		Name:             p.User.Name,
 		Bio:              p.UserProfile.Bio.String,
+		AvatarURL:        avatarURL,
 		ProfileCreatedAt: profileCreatedAt,
 		ProfileUpdatedAt: profileUpdatedAt,
 		IsOwner:          isOwner,

--- a/api/internal/profile/handler/handler.go
+++ b/api/internal/profile/handler/handler.go
@@ -1,20 +1,24 @@
 package handler
 
 import (
+	articlerepository "github.com/Baymax6s/KOBE-Tech/api/internal/article/repository"
 	"github.com/Baymax6s/KOBE-Tech/api/internal/profile/repository"
 	"github.com/gin-gonic/gin"
 )
 
 type Handler struct {
-	repo *repository.Repository
+	repo        *repository.Repository
+	articleRepo *articlerepository.Repository
 }
 
-func NewHandler(repo *repository.Repository) *Handler {
-	return &Handler{repo: repo}
+func NewHandler(repo *repository.Repository, articleRepo *articlerepository.Repository) *Handler {
+	return &Handler{repo: repo, articleRepo: articleRepo}
 }
 
 func (h *Handler) RegisterRoutes(router gin.IRouter, authRouter gin.IRouter) {
 	router.GET("/profile/:user_id", h.getUserProfileHandler)
+	router.GET("/profile/:user_id/articles", h.getUserArticlesHandler)
+	router.GET("/profile/:user_id/liked-articles", h.getUserLikedArticlesHandler)
 	authRouter.PUT("/profile/bio", h.updateBioHandler)
 	authRouter.POST("/profile/avatar/presign", h.presignAvatarHandler)
 	authRouter.POST("/profile/avatar/complete", h.avatarUploadCompleteHandler)

--- a/api/internal/profile/handler/update_bio.go
+++ b/api/internal/profile/handler/update_bio.go
@@ -76,5 +76,5 @@ func (h *Handler) UpdateBio(ctx context.Context, userID int64, req UpdateBioRequ
 		return ProfileJSON{}, err
 	}
 
-	return newProfileJSON(p, true), nil
+	return newProfileJSON(p, true, resolveAvatarURL(ctx, p)), nil
 }

--- a/api/internal/server/router.go
+++ b/api/internal/server/router.go
@@ -19,11 +19,12 @@ import (
 )
 
 func NewHandler(db *sql.DB, validator *auth.Validator, issuer *auth.Issuer) http.Handler {
-	articleHandler := articlehandler.NewHandler(articlerepository.NewRepository(db))
+	articleRepo := articlerepository.NewRepository(db)
+	articleHandler := articlehandler.NewHandler(articleRepo)
 	authHandler := authhandler.NewHandler(authrepository.NewRepository(db), issuer)
 	likeHandler := likehandler.NewHandler(likerepository.NewRepository(db))
 	replyHandler := replyhandler.NewHandler(replyrepository.NewRepository(db))
-	profileHandler := profilehandler.NewHandler(profilerepository.NewRepository(db))
+	profileHandler := profilehandler.NewHandler(profilerepository.NewRepository(db), articleRepo)
 
 	router := gin.Default()
 	router.Use(corsMiddleware())

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -262,6 +262,8 @@ definitions:
     type: object
   server.profileJSON:
     properties:
+      avatar_url:
+        type: string
       bio:
         type: string
       id:
@@ -725,6 +727,60 @@ paths:
           schema:
             $ref: '#/definitions/server.profileErrorResponse'
       summary: Get user profile
+      tags:
+      - profile
+  /api/profile/{user_id}/articles:
+    get:
+      description: 指定ユーザーが投稿した記事一覧を新しい順に取得する
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.listArticlesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/server.profileErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/server.profileErrorResponse'
+      summary: List articles posted by a user
+      tags:
+      - profile
+  /api/profile/{user_id}/liked-articles:
+    get:
+      description: 指定ユーザーがいいねした記事一覧をいいねした順に取得する
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.listArticlesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/server.profileErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/server.profileErrorResponse'
+      summary: List articles liked by a user
       tags:
       - profile
   /api/profile/avatar/complete:

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -751,6 +751,88 @@
                 }
             }
         },
+        "/api/profile/{user_id}/articles": {
+            "get": {
+                "description": "指定ユーザーが投稿した記事一覧を新しい順に取得する",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "List articles posted by a user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.listArticlesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/server.profileErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/server.profileErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/profile/{user_id}/liked-articles": {
+            "get": {
+                "description": "指定ユーザーがいいねした記事一覧をいいねした順に取得する",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "List articles liked by a user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.listArticlesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/server.profileErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/server.profileErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/replies/{reply_id}/best": {
             "put": {
                 "description": "ベストアンサー指定を解除する。質問者のみ可能。",
@@ -1288,6 +1370,9 @@
         "server.profileJSON": {
             "type": "object",
             "properties": {
+                "avatar_url": {
+                    "type": "string"
+                },
                 "bio": {
                     "type": "string"
                 },

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -153,6 +153,7 @@ export interface ServerProfileErrorResponse {
 }
 
 export interface ServerProfileJSON {
+  avatar_url?: string;
   bio?: string;
   id?: number;
   is_owner?: boolean;
@@ -602,6 +603,38 @@ export class Api<
     profileDetail: (userId: number, params: RequestParams = {}) =>
       this.request<ServerProfileJSON, ServerProfileErrorResponse>({
         path: `/api/profile/${userId}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description 指定ユーザーが投稿した記事一覧を新しい順に取得する
+     *
+     * @tags profile
+     * @name ProfileArticlesList
+     * @summary List articles posted by a user
+     * @request GET:/api/profile/{user_id}/articles
+     */
+    profileArticlesList: (userId: number, params: RequestParams = {}) =>
+      this.request<ServerListArticlesResponse, ServerProfileErrorResponse>({
+        path: `/api/profile/${userId}/articles`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description 指定ユーザーがいいねした記事一覧をいいねした順に取得する
+     *
+     * @tags profile
+     * @name ProfileLikedArticlesList
+     * @summary List articles liked by a user
+     * @request GET:/api/profile/{user_id}/liked-articles
+     */
+    profileLikedArticlesList: (userId: number, params: RequestParams = {}) =>
+      this.request<ServerListArticlesResponse, ServerProfileErrorResponse>({
+        path: `/api/profile/${userId}/liked-articles`,
         method: "GET",
         format: "json",
         ...params,

--- a/app/src/features/profile/ProfileView.vue
+++ b/app/src/features/profile/ProfileView.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
 import axios from 'axios'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import ArticleCard from '@/features/articles/ArticleCard.vue'
 import { api } from '@/api/client'
+import type {
+  ServerArticleJSONResponse,
+  ServerProfileJSON,
+} from '@/api/generated/apiSchema'
 import { useAuthStore } from '@/stores/auth'
 
 const props = withDefaults(
@@ -15,45 +21,73 @@ const props = withDefaults(
   },
 )
 
+const route = useRoute()
+const router = useRouter()
 const auth = useAuthStore()
 
-const profile = ref<{
-  id?: number
-  name?: string
-  bio?: string
-  is_owner?: boolean
-} | null>(null)
-
+const profile = ref<ServerProfileJSON | null>(null)
 const loading = ref(true)
 const error = ref<string | null>(null)
+
+const postedArticles = ref<ServerArticleJSONResponse[]>([])
+const likedArticles = ref<ServerArticleJSONResponse[]>([])
+const listsLoading = ref(false)
+const listsError = ref<string | null>(null)
 
 const isEditing = ref(false)
 const bio = ref('')
 const submitting = ref(false)
-
 const maxLength = 200
+
+// 記事一覧の絞り込みと同じ思想で、開いているタブを URL に持たせる。
+// リロード・共有でタブ状態を再現できるようにするため。
+const activeTab = computed<'articles' | 'likes'>({
+  get() {
+    return route.query.tab === 'likes' ? 'likes' : 'articles'
+  },
+  set(next) {
+    void router.replace({
+      query: { ...route.query, tab: next === 'likes' ? 'likes' : undefined },
+    })
+  },
+})
+
+const resolveTargetUserId = async (): Promise<number | null> => {
+  if (!props.isMe) return props.userId
+  if (auth.userId !== null) return auth.userId
+  return auth.fetchUser()
+}
+
+const fetchLists = async (targetId: number) => {
+  listsLoading.value = true
+  listsError.value = null
+  try {
+    const [posted, liked] = await Promise.all([
+      api.api.profileArticlesList(targetId),
+      api.api.profileLikedArticlesList(targetId),
+    ])
+    postedArticles.value = posted.data.articles ?? []
+    likedArticles.value = liked.data.articles ?? []
+  } catch {
+    listsError.value = '記事一覧の取得に失敗しました'
+  } finally {
+    listsLoading.value = false
+  }
+}
 
 const fetchProfile = async () => {
   loading.value = true
   error.value = null
   try {
-    let targetId = props.userId
-    if (props.isMe) {
-      if (auth.userId === null) {
-        const id = await auth.fetchUser()
-        if (id === null) {
-          error.value = 'ユーザー情報の取得に失敗しました'
-          loading.value = false
-          return
-        }
-        targetId = id
-      } else {
-        targetId = auth.userId
-      }
+    const targetId = await resolveTargetUserId()
+    if (targetId === null) {
+      error.value = 'ユーザー情報の取得に失敗しました'
+      return
     }
     const res = await api.api.profileDetail(targetId)
     profile.value = res.data
     bio.value = res.data.bio ?? ''
+    await fetchLists(targetId)
   } catch (err) {
     if (axios.isAxiosError(err) && err.response?.status === 404) {
       error.value = 'ユーザーが見つかりませんでした'
@@ -71,11 +105,8 @@ const saveBio = async () => {
   if (submitting.value) return
   if (bio.value.length > maxLength) return
   submitting.value = true
-
   try {
-    const res = await api.api.profileBioUpdate({
-      bio: bio.value,
-    })
+    const res = await api.api.profileBioUpdate({ bio: bio.value })
     profile.value = res.data
     bio.value = res.data.bio ?? ''
     isEditing.value = false
@@ -85,86 +116,154 @@ const saveBio = async () => {
     submitting.value = false
   }
 }
+
+// プロフィールではタグ絞り込みを持たないので、タグをクリックしたら
+// 記事一覧画面の絞り込みへ遷移させる。
+const goToTag = (tagName: string) => {
+  void router.push({ path: '/articles', query: { tag: tagName } })
+}
 </script>
 
 <template>
-  <v-container class="py-8">
-    <v-row justify="center">
-      <v-col cols="12" sm="10">
-        <v-alert
-          v-if="error"
-          type="error"
-          class="mb-4"
-          closable
-          @click:close="error = null"
-        >
-          {{ error }}
-        </v-alert>
+  <v-sheet color="grey-lighten-4" min-height="100%">
+    <v-container class="py-8">
+      <v-row justify="center">
+        <v-col cols="12" sm="10" md="8">
+          <v-alert
+            v-if="error"
+            type="error"
+            class="mb-4"
+            closable
+            @click:close="error = null"
+          >
+            {{ error }}
+          </v-alert>
 
-        <div v-if="loading" class="d-flex justify-center py-12">
-          <v-progress-circular indeterminate color="primary" />
-        </div>
-
-        <v-card v-if="profile" class="pa-6 text-center elevation-3">
-          <v-avatar size="80" class="mx-auto mb-2" color="indigo-lighten-1">
-            <v-icon size="50" color="white"> mdi-account-circle </v-icon>
-          </v-avatar>
-
-          <h2 class="text-h5 font-weight-bold mb-1">
-            {{ profile.name }}
-          </h2>
-
-          <v-divider class="my-4" />
-
-          <h3 class="text-subtitle-1 font-weight-bold mb-2">自己紹介</h3>
-
-          <div class="text-left">
-            <div v-if="!isEditing">
-              <p class="mb-4">
-                {{ profile.bio || '自己紹介はまだありません' }}
-              </p>
-
-              <v-btn
-                v-if="profile.is_owner"
-                variant="text"
-                color="primary"
-                @click="isEditing = true"
-              >
-                編集
-              </v-btn>
-            </div>
-
-            <div v-else>
-              <v-textarea
-                v-model="bio"
-                :counter="maxLength"
-                :rules="[
-                  (v) =>
-                    v?.length <= maxLength ||
-                    `${maxLength}文字以内で入力してください`,
-                ]"
-                label="自己紹介"
-                variant="outlined"
-                class="mb-3"
-              />
-
-              <v-btn
-                color="primary"
-                class="mr-2"
-                :loading="submitting"
-                :disabled="submitting"
-                @click="saveBio"
-              >
-                完了
-              </v-btn>
-
-              <v-btn variant="text" @click="isEditing = false">
-                キャンセル
-              </v-btn>
-            </div>
+          <div v-if="loading" class="d-flex justify-center py-12">
+            <v-progress-circular indeterminate color="primary" />
           </div>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-container>
+
+          <template v-else-if="profile">
+            <v-card class="pa-6 mb-6" rounded="lg">
+              <div class="d-flex ga-6 align-start">
+                <v-avatar size="96" color="indigo-lighten-1">
+                  <v-img
+                    v-if="profile.avatar_url"
+                    :src="profile.avatar_url"
+                    alt="アバター"
+                  />
+                  <v-icon v-else size="64" color="white">
+                    mdi-account-circle
+                  </v-icon>
+                </v-avatar>
+
+                <div class="flex-grow-1">
+                  <h1 class="text-h5 font-weight-bold mb-2">
+                    {{ profile.name }}
+                  </h1>
+
+                  <template v-if="!isEditing">
+                    <p class="text-body-2 text-medium-emphasis mb-2">
+                      {{ profile.bio || '自己紹介はまだありません' }}
+                    </p>
+                    <v-btn
+                      v-if="profile.is_owner"
+                      variant="text"
+                      color="primary"
+                      size="small"
+                      prepend-icon="mdi-pencil"
+                      @click="isEditing = true"
+                    >
+                      編集
+                    </v-btn>
+                  </template>
+
+                  <template v-else>
+                    <v-textarea
+                      v-model="bio"
+                      :counter="maxLength"
+                      :rules="[
+                        (v) =>
+                          v?.length <= maxLength ||
+                          `${maxLength}文字以内で入力してください`,
+                      ]"
+                      label="自己紹介"
+                      variant="outlined"
+                      rows="3"
+                      class="mb-2"
+                    />
+                    <v-btn
+                      color="primary"
+                      class="mr-2"
+                      :loading="submitting"
+                      :disabled="submitting"
+                      @click="saveBio"
+                    >
+                      完了
+                    </v-btn>
+                    <v-btn variant="text" @click="isEditing = false">
+                      キャンセル
+                    </v-btn>
+                  </template>
+                </div>
+              </div>
+            </v-card>
+
+            <v-tabs v-model="activeTab" color="primary" class="mb-4">
+              <v-tab value="articles">投稿した記事</v-tab>
+              <v-tab value="likes">いいねした記事</v-tab>
+            </v-tabs>
+
+            <div v-if="listsLoading" class="d-flex justify-center py-12">
+              <v-progress-circular indeterminate color="primary" />
+            </div>
+
+            <v-alert v-else-if="listsError" type="error">
+              {{ listsError }}
+            </v-alert>
+
+            <v-window v-else v-model="activeTab">
+              <v-window-item value="articles">
+                <div class="d-flex flex-column ga-4">
+                  <ArticleCard
+                    v-for="article in postedArticles"
+                    :key="article.id"
+                    :article="article"
+                    :selected-tags="[]"
+                    @select-tag="goToTag"
+                  />
+                  <v-alert
+                    v-if="postedArticles.length === 0"
+                    type="info"
+                    variant="tonal"
+                  >
+                    まだ投稿した記事がありません
+                  </v-alert>
+                </div>
+              </v-window-item>
+
+              <v-window-item value="likes">
+                <div class="d-flex flex-column ga-4">
+                  <ArticleCard
+                    v-for="article in likedArticles"
+                    :key="article.id"
+                    :article="article"
+                    :selected-tags="[]"
+                    @select-tag="goToTag"
+                  />
+                  <v-alert
+                    v-if="likedArticles.length === 0"
+                    type="info"
+                    variant="tonal"
+                  >
+                    まだいいねした記事がありません
+                  </v-alert>
+                </div>
+              </v-window-item>
+            </v-window>
+          </template>
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-sheet>
 </template>

--- a/app/src/features/profile/ProfileView.vue
+++ b/app/src/features/profile/ProfileView.vue
@@ -78,6 +78,13 @@ const fetchLists = async (targetId: number) => {
 const fetchProfile = async () => {
   loading.value = true
   error.value = null
+  // 別ユーザーへ遷移した直後にエラーが出ても前のプロフィールが残らないよう、
+  // 取得開始時に表示状態をリセットする。
+  profile.value = null
+  postedArticles.value = []
+  likedArticles.value = []
+  listsError.value = null
+  isEditing.value = false
   try {
     const targetId = await resolveTargetUserId()
     if (targetId === null) {

--- a/docs/requirements-profile.md
+++ b/docs/requirements-profile.md
@@ -80,7 +80,7 @@ likes(id, article_id, user_id, created_at, UNIQUE(article_id, user_id))
 - レイアウトは Vuetify のみで構成（`v-tabs` + `v-window` + `v-card`）。`min-h-screen` は使わず `v-container fill-height` 系で縦を確保（app/AGENTS.md ルール）
 - 記事カードは既存 `ArticleCard.vue` を流用
 - 各タブの空状態（投稿 0 件 / いいね 0 件）を `v-alert` で出す
-- ローディング・エラーはタブ単位で扱う
+- 投稿/いいねの一覧はプロフィール取得後に並行取得し、ローディング・エラーは 2 タブ共通で扱う（同じネットワーク要因で同時に成否が決まることがほとんどなので、タブごとに loading/error フラグを増やさず宣言的に保つ）
 
 ---
 

--- a/docs/requirements-profile.md
+++ b/docs/requirements-profile.md
@@ -1,0 +1,140 @@
+# プロフィール画面リニューアル 要件定義（ドラフト / 壁打ち用）
+
+> ✅ 論点は確定済み（「確定事項」セクション参照）。この内容で実装に入れる状態。
+
+## 概要
+
+他人のプロフィールが閲覧できるようになった（記事詳細の著者名リンク経由）。
+これに合わせてプロフィール画面のレイアウトを刷新し、1 ユーザーの活動が一望できる画面にする。
+
+## ゴール
+
+- プロフィール画面を「ほぼ全画面」のレイアウトに刷新する
+  - **上部（ヘッダー）**: アバターアイコン・名前・自己紹介
+  - **下部（タブ）**: 「投稿した記事」一覧 / 「いいねした記事」一覧の 2 タブ
+- 自分のプロフィール（`/profile/me`）と他人のプロフィール（`/profile/:userId`）を同じ画面で扱う
+- 自分の場合のみ、自己紹介の編集（とアバター変更）ができる
+- バックエンドに「指定ユーザーの投稿記事一覧」「指定ユーザーのいいね記事一覧」を返す API を追加する
+
+## ノンゴール（今回やらない）
+
+- 記事一覧のページネーション（初期は全件一括取得。記事一覧画面も現状ページネーションなし）
+- フォロー / フォロワー
+- プロフィールの公開・非公開設定
+- いいねの取り消しをこの画面から行う動線
+- 記事の編集・削除動線
+
+---
+
+## 現状の把握（コードベース調査結果）
+
+実装方針を決める前提として、今あるものを整理する。
+
+### フロント
+
+- `app/src/features/profile/ProfileView.vue`
+  - `/profile/me`（`isMe` prop）と `/profile/:userId`（`userId` prop）の両方を担う 1 コンポーネント
+  - アバターは `mdi-account-circle` 固定アイコン（**画像表示は未実装**）
+  - `is_owner` のときだけ自己紹介の編集ボタンを表示
+- `app/src/features/articles/ArticleCard.vue`
+  - タイトル・タグ・投稿日・いいね数を表示する再利用可能なカード。**著者名は表示していない**
+- `app/src/features/articles/ArticlesView.vue`
+  - 絞り込み状態を `route.query.tag` に持たせる設計（リロード・共有で再現可能）。タブ状態の設計もこれに倣える
+- ルーティングは `/profile/me`（`requiresAuth`）と `/profile/:userId(\d+)`（公開）
+
+### バックエンド
+
+- `GET /api/profile/{user_id}` … `id` / `name` / `bio` / `is_owner` を返す。**アバターURL は返していない**
+  - `user_profiles` テーブルに `object_key`・`is_uploaded` はあるが、取得 API では使っていない
+  - アバターのアップロードは `POST /api/profile/avatar/presign` → `/complete` で実装済み（MinIO）
+- `GET /api/articles` … タグ絞り込み（AND）のみ。**`user_id` での絞り込みは未対応**
+  - 一覧でも本文 `content` を**全文**返している（プロフィールで記事が増えると転送量が無駄）
+- いいねは `likes(article_id, user_id, created_at)`。**「ユーザーのいいね記事一覧」を返す API は未実装**
+
+### スキーマ（関連分）
+
+```
+users(id, name, password_hash, ...)
+user_profiles(id, user_id UNIQUE, object_key, bio, is_uploaded, created_at, updated_at)
+articles(id, title, content, user_id, created_at, updated_at)
+likes(id, article_id, user_id, created_at, UNIQUE(article_id, user_id))
+```
+
+---
+
+## 画面要件（ドラフト）
+
+```text
+┌─────────────────────────────────────┐
+│  [アバター]  名前                      │  ← ヘッダー
+│              自己紹介テキスト…          │     (自分なら「編集」ボタン)
+├─────────────────────────────────────┤
+│  [ 投稿した記事 ]  [ いいねした記事 ]    │  ← v-tabs
+├─────────────────────────────────────┤
+│  ArticleCard                         │  ← v-window で切替
+│  ArticleCard                         │
+│  ...                                 │
+└─────────────────────────────────────┘
+```
+
+- レイアウトは Vuetify のみで構成（`v-tabs` + `v-window` + `v-card`）。`min-h-screen` は使わず `v-container fill-height` 系で縦を確保（app/AGENTS.md ルール）
+- 記事カードは既存 `ArticleCard.vue` を流用
+- 各タブの空状態（投稿 0 件 / いいね 0 件）を `v-alert` で出す
+- ローディング・エラーはタブ単位で扱う
+
+---
+
+## バックエンド設計（ドラフト）
+
+### 追加エンドポイント案
+
+| メソッド | パス | 用途 |
+| -------- | ---- | ---- |
+| `GET` | `/api/profile/{user_id}/articles` | そのユーザーが投稿した記事一覧 |
+| `GET` | `/api/profile/{user_id}/liked-articles` | そのユーザーがいいねした記事一覧 |
+
+- レスポンスは既存の `listArticlesResponse`（`ArticleListItemJSON`）を再利用する想定
+- `liked_by_me` は「閲覧者(current user)が」いいね済みか。プロフィール対象ユーザーのいいねとは別概念なので混同しない
+
+### クエリの骨子
+
+- 投稿一覧: `WHERE a.user_id = $target`
+- いいね一覧: `WHERE a.id IN (SELECT article_id FROM likes WHERE user_id = $target)`
+  - 並び順は「いいねした順（`likes.created_at DESC`）」か「記事投稿順」かが論点（下記）
+
+---
+
+## 確定事項
+
+| # | 論点 | 決定 |
+| - | ---- | ---- |
+| 1 | 投稿記事一覧 API の置き場所 | **profile 配下に新規** `GET /api/profile/{user_id}/articles` |
+| 2 | 他人の「いいね一覧」公開 | **全員に公開**（`/api/profile/{user_id}/liked-articles`） |
+| 3 | アバター画像表示 | **今回スコープに含める**。プロフィール取得 API に `avatar_url` を追加 |
+| 4 | タブ状態 | **URL に保持**（`?tab=articles\|likes`） |
+| 5 | いいね一覧の並び順 | **いいねした順**（`likes.created_at DESC`） |
+| 6 | 一覧 API が本文を全文返す件 | **現状踏襲**（スコープを膨らませない。別途リファクタ扱い） |
+
+### 論点 3 の詳細（アバター）
+
+- `GET /api/profile/{user_id}` のレスポンスに `avatar_url` を追加する
+- `is_uploaded = true` のとき、`object_key` から **presigned GET URL** を生成して返す（既存 MinIO クライアントを利用）
+- 未アップロード時は `avatar_url` を空にし、フロントは従来どおり `mdi-account-circle` にフォールバック
+
+### 論点 1・2 の詳細（一覧 API）
+
+- どちらも既存の `listArticlesResponse`（`ArticleListItemJSON`）を再利用
+- `liked_by_me` は閲覧者(current user)基準。プロフィール対象ユーザーのいいねとは別概念
+- 並び順
+  - 投稿一覧: `articles.created_at DESC`
+  - いいね一覧: `likes.created_at DESC`
+
+---
+
+## 想定する作業の流れ（確定後）
+
+1. マイグレーション不要（既存テーブルで足りる想定）
+2. `api/internal/profile/handler` & `repository` に一覧取得を追加（or article 側に追加）→ swag アノテーション
+3. `cd api && make swagger` → `cd app && npm run generate:api`
+4. `ProfileView.vue` をヘッダー + タブ構成に刷新
+5. （論点3がAなら）アバターURL対応


### PR DESCRIPTION
## やったこと

プロフィール画面を刷新し、自分・他人どちらのプロフィールも「上部にアバター/名前/自己紹介、下部に投稿記事・いいね記事のタブ」で一望できるようにしました。記事詳細の著者名リンクから他人のプロフィールへ遷移できます。

### フロントエンド（`app/`）
- `ProfileView.vue` を **ヘッダー + タブ**構成に刷新（`v-tabs` + `v-window`）
  - 上部: アバター・名前・自己紹介（自分のときだけ自己紹介を編集できる）
  - 下部: 「投稿した記事」/「いいねした記事」の2タブ。各記事は既存 `ArticleCard` を流用
- アバターは `avatar_url` があれば画像、なければ既定アイコン（`mdi-account-circle`）
- 開いているタブを `?tab=articles|likes` として URL に保持（リロード・共有でタブ状態を再現）

### バックエンド（`api/`）
- `GET /api/profile/{user_id}/articles` … 投稿記事を新しい順に返す
- `GET /api/profile/{user_id}/liked-articles` … いいねした記事を**いいねした順**に返す
- `GET /api/profile/{user_id}` のレスポンスに `avatar_url`（presigned GET URL）を追加
- 記事一覧系クエリの `SELECT/FROM` 句と行スキャンを共通化（重複排除）

### ドキュメント
- `docs/requirements-profile.md` … 要件・現状調査・確定した設計判断をまとめた要件定義

---

## レビューの歩き方（おすすめ順）

初めて見る人はこの順で読むと流れがつかめます。

1. **`docs/requirements-profile.md`** … 何を作るか・なぜこの設計かの全体像
2. **`api/internal/profile/handler/get_user_articles.go`** … 追加した2エンドポイント本体（薄い）
3. **`api/internal/article/repository/list_profile_articles.go`** … 記事取得SQL（2メソッド）
4. **`app/src/features/profile/ProfileView.vue`** … 画面本体

> `api/swagger/*` と `app/src/api/generated/apiSchema.ts` は**自動生成物**です。手では編集していません（Goのハンドラ→`make swagger`→`npm run generate:api` で再生成）。レビューでは読み飛ばしてOKです。

---

## 設計判断とその理由

### 1. 記事取得SQLは「記事ドメイン(`article/repository`)」に置き、ハンドラは「`profile/handler`」に置いた
- **やったこと**: `ListArticlesByAuthor` / `ListLikedArticles` を `article/repository` に追加し、`profile/handler` がそれを呼ぶ（`profile` に `article/repository` を注入）
- **なぜ**: 記事を取ってくる知識は記事ドメインのもの。これを profile 側にコピーすると、記事の列が増えたときに**両方を直さないとバグる**温床になる。一方で URL は `/profile/...` なので、ハンドラとルーティングはパスに合わせて `profile` に置き、「URLとコードの場所が一致して読みやすい」状態を優先した

### 2. 一覧クエリの `SELECT/FROM` とスキャン処理を共通化した
- **やったこと**: 既存 `ListArticles` から `articleListSelectFrom`（共通のSELECT/FROM句）と `scanArticleList`（行読み出し）を切り出し、新2メソッドと共有
- **なぜ**: 同じ列構成のクエリが3つ並ぶと、列の追加・並び替えのたびに3箇所を揃える必要が出る。「列の順番とスキャンの順番を合わせる」責務を1箇所に集約することで、ズレによるバグを防いだ

### 3. いいね一覧の ❤️（`liked_by_me`）は「閲覧者」基準
- **やったこと**: いいね一覧には「対象ユーザーがいいねした記事」が並ぶが、各カードの ❤️ が赤いのは**閲覧者自身が**いいね済みの記事
- **なぜ**: 記事一覧で使っている既存レスポンス（`listArticlesResponse`）をそのまま再利用するため。型を1つに保つことでフロント・バックの認識ズレを防げる。「対象ユーザーのいいね」と「自分のいいね」は別概念なので混同しないよう注意

### 4. アバターURLはプロフィールヘッダーの1枚だけ生成する
- **やったこと**: presigned GET URL を発行するのは `GET /api/profile/{user_id}` のときだけ。記事一覧・記事詳細の著者にはアバターを出さない
- **なぜ**: 一覧APIにアバターを足すと記事の件数ぶん署名URLを生成することになり重い。プロフィールに来て初めてアバターを表示する方針にしてコストを抑えた
- **失敗時の扱い**: ストレージ接続や署名に失敗してもプロフィール取得自体は止めず、`avatar_url` を空で返してフロントの既定アイコンにフォールバックする（プロフィールが丸ごと見られなくなるのを防ぐため）

### 5. タブ状態を URL に持たせた
- **やったこと**: `?tab=articles|likes` を URL と双方向バインド
- **なぜ**: 記事一覧の絞り込み（`?tag=`）と同じ思想。リロード・ブックマーク・共有でタブ状態が再現でき、ローカルの `ref` で持つより状態の出どころが1つで分かりやすい

---

## 動作確認
- `api`: `go vet ./...` / `go build` / `gofmt -l` … クリーン
- `app`: `vue-tsc --noEmit` / `eslint` / `npm run build` … クリーン
- ローカル起動（`make dev` + `npm run dev`）での画面確認は別途お願いできると安心です。確認観点:
  - [x] 記事詳細の著者名リンクから他人プロフィールへ遷移できる
  - [x] 自分のプロフィールでのみ自己紹介の「編集」が出る
  - <img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/f381abcd-4c32-4e75-a3ae-ca30c8048d4c" />
  - [x] 投稿/いいねタブの切り替えと、空状態の表示
  - <img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/db3bacde-5dcd-461c-9e67-03a68a7b5bcf" />
  - [x] アバター画像をアップロード済みのユーザーで画像が表示される
  - <img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/91e1dc0d-d11d-41d7-ad40-3efc4ce29c3f" />
  - minioに画像をアップロードしてdbに直接レコードを作成して検証


Closes #248  #269
