### PR TITLE
記事詳細画面に著者のアイコン画像を追加

### DIFF
--- a/api/internal/article/article.go
+++ b/api/internal/article/article.go
@@ -1,6 +1,7 @@
 package article
 
 import (
+	"database/sql"
 	"errors"
 	"strings"
 	"time"
@@ -15,8 +16,10 @@ var (
 const maxTagNameLength = 10
 
 type Author struct {
-	ID   int64
-	Name string
+	ID              int64
+	Name            string
+	AvatarObjectKey sql.NullString
+	AvatarUploaded  bool
 }
 
 type Article struct {

--- a/api/internal/article/handler/get_article.go
+++ b/api/internal/article/handler/get_article.go
@@ -9,12 +9,14 @@ import (
 	"time"
 
 	"github.com/Baymax6s/KOBE-Tech/api/internal/auth"
+	"github.com/Baymax6s/KOBE-Tech/api/internal/minio"
 	"github.com/gin-gonic/gin"
 )
 
 type AuthorJSON struct {
-	ID   int64  `json:"id" binding:"required"`
-	Name string `json:"name" binding:"required"`
+	ID        int64  `json:"id" binding:"required"`
+	Name      string `json:"name" binding:"required"`
+	AvatarURL string `json:"avatar_url"`
 } // @name server.articleAuthorJSONResponse
 
 type GetArticleJSONResponse struct {
@@ -84,8 +86,9 @@ func (h *Handler) GetArticle(ctx context.Context, articleID int64, userID int64)
 		Title:   item.Title,
 		Content: item.Content,
 		Author: AuthorJSON{
-			ID:   item.Author.ID,
-			Name: item.Author.Name,
+			ID:        item.Author.ID,
+			Name:      item.Author.Name,
+			AvatarURL: minio.ResolveAvatarURL(ctx, item.Author.AvatarObjectKey.String, item.Author.AvatarUploaded),
 		},
 		Tags:       newArticleTagJSONs(item.Tags),
 		CreatedAt:  item.CreatedAt,

--- a/api/internal/article/repository/get_article.go
+++ b/api/internal/article/repository/get_article.go
@@ -20,6 +20,8 @@ func (r *Repository) FindArticleByID(ctx context.Context, id int64, userID int64
 			a.content,
 			u.id,
 			u.name,
+			up.object_key,
+			COALESCE(up.is_uploaded, false),
 			a.created_at,
 			a.updated_at,
 			COALESCE((SELECT COUNT(*) FROM likes WHERE article_id = a.id), 0),
@@ -28,6 +30,7 @@ func (r *Repository) FindArticleByID(ctx context.Context, id int64, userID int64
 			EXISTS(SELECT 1 FROM likes WHERE article_id = a.id AND user_id = $2)
 		FROM articles a
 		JOIN users u ON u.id = a.user_id
+		LEFT JOIN user_profiles up ON up.user_id = u.id
 		LEFT JOIN LATERAL (
 			SELECT
 				array_agg(t.id ORDER BY t.name, t.id) AS tag_ids,
@@ -48,6 +51,8 @@ func (r *Repository) FindArticleByID(ctx context.Context, id int64, userID int64
 		&item.Content,
 		&item.Author.ID,
 		&item.Author.Name,
+		&item.Author.AvatarObjectKey,
+		&item.Author.AvatarUploaded,
 		&item.CreatedAt,
 		&item.UpdatedAt,
 		&item.LikesCount,

--- a/api/internal/minio/avatar.go
+++ b/api/internal/minio/avatar.go
@@ -3,7 +3,6 @@ package minio
 import (
 	"context"
 	"log"
-	"os"
 )
 
 // ResolveAvatarURL はアバターがアップロード済みのときだけ presigned GET URL を返す。
@@ -20,7 +19,7 @@ func ResolveAvatarURL(ctx context.Context, objectKey string, isUploaded bool) st
 		return ""
 	}
 
-	url, err := GeneratePresignedGetURL(ctx, client, os.Getenv("MINIO_BUCKET_NAME"), objectKey)
+	url, err := GeneratePresignedGetURL(ctx, client, bucketName, objectKey)
 	if err != nil {
 		log.Printf("avatar url: presign: %v", err)
 		return ""

--- a/api/internal/minio/avatar.go
+++ b/api/internal/minio/avatar.go
@@ -1,0 +1,30 @@
+package minio
+
+import (
+	"context"
+	"log"
+	"os"
+)
+
+// ResolveAvatarURL はアバターがアップロード済みのときだけ presigned GET URL を返す。
+// ストレージ接続や署名に失敗してもプロフィール/記事の取得自体は止めず、空文字を返して
+// フロント側のフォールバック表示（既定アイコン）に委ねる。
+func ResolveAvatarURL(ctx context.Context, objectKey string, isUploaded bool) string {
+	if !isUploaded || objectKey == "" {
+		return ""
+	}
+
+	client, err := NewClient()
+	if err != nil {
+		log.Printf("avatar url: connect storage: %v", err)
+		return ""
+	}
+
+	url, err := GeneratePresignedGetURL(ctx, client, os.Getenv("MINIO_BUCKET_NAME"), objectKey)
+	if err != nil {
+		log.Printf("avatar url: presign: %v", err)
+		return ""
+	}
+
+	return url
+}

--- a/api/internal/minio/client.go
+++ b/api/internal/minio/client.go
@@ -14,19 +14,27 @@ import (
 
 var (
 	clientInstance *minioSDK.Client
+	bucketName     string
 	initError      error
 	once           sync.Once
 )
+
+// BucketName は NewClient が解決・検証済みのバケット名を返す。
+// 環境変数を読み直すと正規化（前後空白の除去）がズレる余地があるため、
+// バケット名の出どころはこの 1 か所に集約する。NewClient 成功後にのみ有効。
+func BucketName() string {
+	return bucketName
+}
 
 func NewClient() (*minioSDK.Client, error) {
 
 	once.Do(func() {
 		endpoint := strings.TrimSpace(os.Getenv("MINIO_ENDPOINT"))
-		bucketName := strings.TrimSpace(os.Getenv("MINIO_BUCKET_NAME"))
+		bucket := strings.TrimSpace(os.Getenv("MINIO_BUCKET_NAME"))
 		accessKey := strings.TrimSpace(os.Getenv("MINIO_ROOT_USER"))
 		secretKey := strings.TrimSpace(os.Getenv("MINIO_ROOT_PASSWORD"))
 
-		if endpoint == "" || bucketName == "" || accessKey == "" || secretKey == "" {
+		if endpoint == "" || bucket == "" || accessKey == "" || secretKey == "" {
 			initError = errors.New("MINIO_ENDPOINT, MINIO_BUCKET_NAME, MINIO_ROOT_USER, and MINIO_ROOT_PASSWORD must be set")
 			return
 		}
@@ -43,17 +51,18 @@ func NewClient() (*minioSDK.Client, error) {
 		}
 
 		ctx := context.Background()
-		exists, err := client.BucketExists(ctx, bucketName)
+		exists, err := client.BucketExists(ctx, bucket)
 		if err != nil {
-			initError = fmt.Errorf("failed to verify bucket %q: %w", bucketName, err)
+			initError = fmt.Errorf("failed to verify bucket %q: %w", bucket, err)
 			return
 		}
 		if !exists {
-			initError = fmt.Errorf("bucket %q does not exist", bucketName)
+			initError = fmt.Errorf("bucket %q does not exist", bucket)
 			return
 		}
 
 		clientInstance = client
+		bucketName = bucket
 	})
 
 	if initError != nil {

--- a/api/internal/profile/handler/get_user_profile.go
+++ b/api/internal/profile/handler/get_user_profile.go
@@ -3,9 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
-	"log"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -76,27 +74,8 @@ func (h *Handler) GetProfile(ctx context.Context, targetUserID int64, currentUse
 	return newProfileJSON(p, isOwner, resolveAvatarURL(ctx, p)), nil
 }
 
-// resolveAvatarURL はアバターがアップロード済みのときだけ presigned GET URL を返す。
-// ストレージ接続や署名に失敗してもプロフィール取得自体は止めず、空文字を返して
-// フロント側のフォールバック表示（既定アイコン）に委ねる。
 func resolveAvatarURL(ctx context.Context, p profile.Profile) string {
-	if !p.UserProfile.IsUploaded || !p.UserProfile.ObjectKey.Valid || p.UserProfile.ObjectKey.String == "" {
-		return ""
-	}
-
-	client, err := minio.NewClient()
-	if err != nil {
-		log.Printf("avatar url: connect storage: %v", err)
-		return ""
-	}
-
-	url, err := minio.GeneratePresignedGetURL(ctx, client, os.Getenv("MINIO_BUCKET_NAME"), p.UserProfile.ObjectKey.String)
-	if err != nil {
-		log.Printf("avatar url: presign: %v", err)
-		return ""
-	}
-
-	return url
+	return minio.ResolveAvatarURL(ctx, p.UserProfile.ObjectKey.String, p.UserProfile.IsUploaded)
 }
 
 func newProfileJSON(p profile.Profile, isOwner bool, avatarURL string) ProfileJSON {

--- a/api/internal/profile/handler/presign_avatar.go
+++ b/api/internal/profile/handler/presign_avatar.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 
 	"github.com/Baymax6s/KOBE-Tech/api/internal/auth"
@@ -83,9 +82,7 @@ func (h *Handler) presignAvatarHandler(c *gin.Context) {
 		return
 	}
 
-	bucketName := os.Getenv("MINIO_BUCKET_NAME")
-
-	url, err := minio.GeneratePresignedPutURL(c.Request.Context(), client, bucketName, objectKey)
+	url, err := minio.GeneratePresignedPutURL(c.Request.Context(), client, minio.BucketName(), objectKey)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{Message: "failed to generate presigned URL"})
 		return
@@ -137,9 +134,7 @@ func (h *Handler) avatarUploadCompleteHandler(c *gin.Context) {
 		return
 	}
 
-	bucketName := os.Getenv("MINIO_BUCKET_NAME")
-
-	objInfo, err := client.StatObject(c.Request.Context(), bucketName, req.ObjectKey, minioSDK.StatObjectOptions{})
+	objInfo, err := client.StatObject(c.Request.Context(), minio.BucketName(), req.ObjectKey, minioSDK.StatObjectOptions{})
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Message: "uploaded file not found or inaccessible"})
 		return

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -28,6 +28,8 @@ definitions:
     type: object
   server.articleAuthorJSONResponse:
     properties:
+      avatar_url:
+        type: string
       id:
         type: integer
       name:

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -1025,6 +1025,9 @@
                 "name"
             ],
             "properties": {
+                "avatar_url": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "integer"
                 },

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -30,6 +30,7 @@ export interface HandlerPresignAvatarResponse {
 }
 
 export interface ServerArticleAuthorJSONResponse {
+  avatar_url?: string;
   id: number;
   name: string;
 }

--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -77,6 +77,12 @@ const formattedDate = useDateFormat(
   'YYYY/MM/DD',
 )
 
+const authorProfilePath = computed(() =>
+  article.value?.author?.id === auth.userId
+    ? '/profile/me'
+    : `/profile/${article.value?.author?.id}`,
+)
+
 watch(
   () => props.articleId,
   async (id) => {
@@ -131,21 +137,27 @@ watch(
               </v-chip>
             </div>
 
-            <div class="text-body-2 text-medium-emphasis mb-6">
-              <div>
-                <div>
-                  著者
-                  <RouterLink
-                    :to="
-                      article.author?.id === auth.userId
-                        ? '/profile/me'
-                        : `/profile/${article.author?.id}`
-                    "
-                    class="text-decoration-none text-primary"
-                  >
-                    {{ article.author?.name }}
-                  </RouterLink>
-                </div>
+            <div class="d-flex align-center ga-3 mb-6">
+              <RouterLink :to="authorProfilePath" class="text-decoration-none">
+                <v-avatar size="40" color="indigo-lighten-1">
+                  <v-img
+                    v-if="article.author?.avatar_url"
+                    :src="article.author.avatar_url"
+                    alt="アバター"
+                  />
+                  <v-icon v-else size="28" color="white">
+                    mdi-account-circle
+                  </v-icon>
+                </v-avatar>
+              </RouterLink>
+
+              <div class="text-body-2 text-medium-emphasis">
+                <RouterLink
+                  :to="authorProfilePath"
+                  class="text-decoration-none text-primary font-weight-medium"
+                >
+                  {{ article.author?.name }}
+                </RouterLink>
                 <div>投稿日 {{ formattedDate }}</div>
               </div>
             </div>


### PR DESCRIPTION
## やったこと
- 記事詳細取得apiにアバターのURLパスのレスポンスを追加
- 記事詳細画面においてアイコン、著者名、投稿日の情報が表示されるように変更

## 動作確認
- 記事詳細画面において　アイコン画像と著者名と投稿日が表示される （中身が入っているものとデフォルトアイコンの二つを確認）
- <img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/be64c5b3-ebd3-4475-b771-a5c7de37d502" />
- <img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/faa8bdb4-8c4f-4d06-b3d4-7bab099e9189" />
- アイコンと名前のどっちをクリックしても正しく、プロフィール画面に遷移する


