### PR TITLE
連鎖制限バックエンド

### DIFF
--- a/api/internal/reply/handler/create_reply.go
+++ b/api/internal/reply/handler/create_reply.go
@@ -58,7 +58,7 @@ func (h *Handler) createReplyHandler(c *gin.Context) {
 			errors.Is(err, repository.ErrInvalidParent),
 			errors.Is(err, repository.ErrInvalidRootKind),
 			errors.Is(err, repository.ErrParentMismatch),
-		errors.Is(err, repository.ErrMaxDepthExceeded):
+			errors.Is(err, repository.ErrMaxDepthExceeded):
 			c.JSON(http.StatusBadRequest, ErrorResponse{Message: err.Error()})
 		case errors.Is(err, repository.ErrArticleNotFound), errors.Is(err, repository.ErrParentNotFound):
 			c.JSON(http.StatusNotFound, ErrorResponse{Message: err.Error()})

--- a/api/internal/reply/handler/create_reply.go
+++ b/api/internal/reply/handler/create_reply.go
@@ -57,7 +57,8 @@ func (h *Handler) createReplyHandler(c *gin.Context) {
 			errors.Is(err, reply.ErrInvalidKind),
 			errors.Is(err, repository.ErrInvalidParent),
 			errors.Is(err, repository.ErrInvalidRootKind),
-			errors.Is(err, repository.ErrParentMismatch):
+			errors.Is(err, repository.ErrParentMismatch),
+		errors.Is(err, repository.ErrMaxDepthExceeded):
 			c.JSON(http.StatusBadRequest, ErrorResponse{Message: err.Error()})
 		case errors.Is(err, repository.ErrArticleNotFound), errors.Is(err, repository.ErrParentNotFound):
 			c.JSON(http.StatusNotFound, ErrorResponse{Message: err.Error()})

--- a/api/internal/reply/repository/create_reply.go
+++ b/api/internal/reply/repository/create_reply.go
@@ -54,7 +54,7 @@ func (r *Repository) Create(ctx context.Context, articleID int64, userID int64, 
 		if depth, err := fetchParentDepth(ctx, tx, *parentID); err != nil {
 			return reply.Reply{}, err
 		} else if depth >= maxReplyDepth {
-			return reply.Reply{}, errors.New("max reply depth exceeded")
+			return reply.Reply{}, ErrMaxDepthExceeded
 		}
 	}
 

--- a/api/internal/reply/repository/create_reply.go
+++ b/api/internal/reply/repository/create_reply.go
@@ -9,6 +9,8 @@ import (
 	"github.com/lib/pq"
 )
 
+const maxReplyDepth = 2
+
 func (r *Repository) Create(ctx context.Context, articleID int64, userID int64, parentID *int64, kind reply.Kind, body string) (reply.Reply, error) {
 	if r == nil || r.db == nil {
 		return reply.Reply{}, errors.New("reply repository is not configured")
@@ -48,6 +50,11 @@ func (r *Repository) Create(ctx context.Context, articleID int64, userID int64, 
 		}
 		if kind != expected {
 			return reply.Reply{}, ErrInvalidParent
+		}
+		if depth, err := fetchParentDepth(ctx, tx, *parentID); err != nil {
+			return reply.Reply{}, err
+		} else if depth >= maxReplyDepth {
+			return reply.Reply{}, errors.New("max reply depth exceeded")
 		}
 	}
 
@@ -127,4 +134,22 @@ func nullableInt64(v *int64) sql.NullInt64 {
 		return sql.NullInt64{}
 	}
 	return sql.NullInt64{Int64: *v, Valid: true}
+}
+
+func fetchParentDepth(ctx context.Context, tx *sql.Tx, parentID int64) (int, error) {
+	const query = `
+		WITH RECURSIVE ancestors AS (
+			SELECT id, parent_id, 0 AS depth FROM replies WHERE id = $1
+			UNION ALL
+			SELECT r.id, r.parent_id, a.depth + 1
+			FROM replies r
+			INNER JOIN ancestors a ON r.id = a.parent_id
+		)
+		SELECT COALESCE(MAX(depth), 0) FROM ancestors
+	`
+	var depth int
+	if err := tx.QueryRowContext(ctx, query, parentID).Scan(&depth); err != nil {
+		return 0, err
+	}
+	return depth, nil
 }

--- a/api/internal/reply/repository/repository.go
+++ b/api/internal/reply/repository/repository.go
@@ -16,6 +16,7 @@ var (
 	ErrNotQuestionAuthor    = errors.New("only the question author can mark a best answer")
 	ErrBestAnswerAlreadySet = errors.New("best answer already exists for this question")
 	ErrNotBestAnswer        = errors.New("reply is not marked as best answer")
+	ErrMaxDepthExceeded     = errors.New("max reply depth exceeded")
 )
 
 type Repository struct {


### PR DESCRIPTION
## やったこと
api/internal/reply/repository/create_reply.go — 1ファイルのみ
1. maxReplyDepth = 2 を定数定義（L12）
2. 返信作成時に親の深さを再帰CTEでチェック（L54-58）— 親の深さが2以上なら errors.New("max reply depth exceeded") を返す
3. fetchParentDepth 関数を追加（L139-155）— 親返信IDからルートまでの深さを再帰CTEで計算
handler/create_reply.go	switch に ErrMaxDepthExceeded → 400 の分岐を追加、gofmt インデント修正

## 動作確認
<img width="1918" height="990" alt="image" src="https://github.com/user-attachments/assets/904373c1-10fd-4179-910e-0ba4747453db" />

Closes #274