### PR TITLE
feat(app): プロフィールのアイコン画像変更UIを追加（統一編集モード）

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -18,6 +18,7 @@
         "md-editor-v3": "^6.5.0",
         "pinia": "^3.0.4",
         "vue": "^3.5.32",
+        "vue-advanced-cropper": "^2.8.9",
         "vue-router": "^4.6.4",
         "vuetify": "^4.0.6"
       },
@@ -3689,6 +3690,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -3920,6 +3927,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4057,6 +4070,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/easy-bem": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/easy-bem/-/easy-bem-1.1.1.tgz",
+      "integrity": "sha512-GJRqdiy2h+EXy6a8E6R+ubmqUM08BK0FWNq41k24fup6045biQ8NXxoXimiwegMQvFFV3t1emADdGNL1TlS61A==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.340",
@@ -7589,6 +7608,24 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-advanced-cropper": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/vue-advanced-cropper/-/vue-advanced-cropper-2.8.9.tgz",
+      "integrity": "sha512-1jc5gO674kVGpJKekoaol6ZlwaF5VYDLSBwBOUpViW0IOrrRsyLw6XNszjEqgbavvqinlKNS6Kqlom3B5M72Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.6",
+        "debounce": "^1.2.0",
+        "easy-bem": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-eslint-parser": {

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "md-editor-v3": "^6.5.0",
     "pinia": "^3.0.4",
     "vue": "^3.5.32",
+    "vue-advanced-cropper": "^2.8.9",
     "vue-router": "^4.6.4",
     "vuetify": "^4.0.6"
   },

--- a/app/src/features/profile/AvatarEditDialog.vue
+++ b/app/src/features/profile/AvatarEditDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useDropZone, useFileDialog } from '@vueuse/core'
 import axios from 'axios'
-import { ref, watch } from 'vue'
+import { onBeforeUnmount, ref, watch } from 'vue'
 import { Cropper, CircleStencil } from 'vue-advanced-cropper'
 import 'vue-advanced-cropper/dist/style.css'
 import { api } from '@/api/client'
@@ -49,21 +49,28 @@ const { isOverDropZone } = useDropZone(dropZoneRef, {
   onDrop: (files) => acceptFile(files?.[0]),
 })
 
+const revokeImageSrc = () => {
+  if (imageSrc.value) URL.revokeObjectURL(imageSrc.value)
+}
+
 // 選択ファイルが変わるたびにプレビュー用 Object URL を張り替え、前の URL は解放する。
 watch(selectedFile, (file) => {
-  if (imageSrc.value) URL.revokeObjectURL(imageSrc.value)
+  revokeImageSrc()
   imageSrc.value = file ? URL.createObjectURL(file) : undefined
   error.value = undefined
 })
 
 watch(open, (isOpen) => {
   if (isOpen) return
-  if (imageSrc.value) URL.revokeObjectURL(imageSrc.value)
+  revokeImageSrc()
   imageSrc.value = undefined
   selectedFile.value = undefined
   error.value = undefined
   resetFileDialog()
 })
+
+// ダイアログを開いたままルート遷移などで unmount された場合の解放漏れを防ぐ。
+onBeforeUnmount(revokeImageSrc)
 
 const cropToJpegBlob = (): Promise<Blob | null> =>
   new Promise((resolve) => {
@@ -90,10 +97,10 @@ const save = async () => {
       return
     }
 
-    const { data: presign } = await api.api.profileAvatarPresignCreate({
-      size: blob.size,
-      contentType: 'image/jpeg',
-    })
+    const { data: presign } = await api.api.profileAvatarPresignCreate(
+      { size: blob.size, contentType: 'image/jpeg' },
+      { skipGlobalErrorHandler: true },
+    )
     if (!presign.url || !presign.objectKey) {
       error.value = 'アバターの更新に失敗しました'
       return
@@ -105,7 +112,10 @@ const save = async () => {
       headers: { 'Content-Type': 'image/jpeg' },
     })
 
-    await api.api.profileAvatarCompleteCreate({ objectKey: presign.objectKey })
+    await api.api.profileAvatarCompleteCreate(
+      { objectKey: presign.objectKey },
+      { skipGlobalErrorHandler: true },
+    )
 
     emit('uploaded')
     open.value = false

--- a/app/src/features/profile/AvatarEditDialog.vue
+++ b/app/src/features/profile/AvatarEditDialog.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import axios from 'axios'
+import { ref, watch } from 'vue'
+import { Cropper, CircleStencil } from 'vue-advanced-cropper'
+import 'vue-advanced-cropper/dist/style.css'
+import { api } from '@/api/client'
+
+// アバターは 1 ユーザー 1 枚で上書き保存される。サーバ側は 2MB / png・jpeg のみ
+// 受け付けるため、ここでクロップ結果を 512px 四方の JPEG に正規化して制約を満たす。
+const MAX_OUTPUT_SIZE = 512
+const MAX_UPLOAD_BYTES = 2 * 1024 * 1024
+const JPEG_QUALITY = 0.9
+
+const open = defineModel<boolean>({ required: true })
+const emit = defineEmits<{ uploaded: [] }>()
+
+const cropperRef = ref<InstanceType<typeof Cropper>>()
+const selectedFile = ref<File>()
+const imageSrc = ref<string>()
+const submitting = ref(false)
+const error = ref<string>()
+
+// 選択ファイルが変わるたびにプレビュー用 Object URL を張り替え、前の URL は解放する。
+watch(selectedFile, (file) => {
+  if (imageSrc.value) URL.revokeObjectURL(imageSrc.value)
+  imageSrc.value = file ? URL.createObjectURL(file) : undefined
+  error.value = undefined
+})
+
+watch(open, (isOpen) => {
+  if (isOpen) return
+  if (imageSrc.value) URL.revokeObjectURL(imageSrc.value)
+  imageSrc.value = undefined
+  selectedFile.value = undefined
+  error.value = undefined
+})
+
+const cropToJpegBlob = (): Promise<Blob | null> =>
+  new Promise((resolve) => {
+    const canvas = cropperRef.value?.getResult().canvas
+    if (!canvas) {
+      resolve(null)
+      return
+    }
+    canvas.toBlob((blob) => resolve(blob), 'image/jpeg', JPEG_QUALITY)
+  })
+
+const save = async () => {
+  if (submitting.value) return
+  submitting.value = true
+  error.value = undefined
+  try {
+    const blob = await cropToJpegBlob()
+    if (!blob) {
+      error.value = '画像を選択してください'
+      return
+    }
+    if (blob.size > MAX_UPLOAD_BYTES) {
+      error.value = '画像が大きすぎます（2MB以下にしてください）'
+      return
+    }
+
+    const { data: presign } = await api.api.profileAvatarPresignCreate({
+      size: blob.size,
+      contentType: 'image/jpeg',
+    })
+    if (!presign.url || !presign.objectKey) {
+      error.value = 'アバターの更新に失敗しました'
+      return
+    }
+
+    // presigned PUT は MinIO へ直接送る。api クライアント（Authorization 付与）を
+    // 通すと署名対象外のヘッダが混ざるため、素の axios でアップロードする。
+    await axios.put(presign.url, blob, {
+      headers: { 'Content-Type': 'image/jpeg' },
+    })
+
+    await api.api.profileAvatarCompleteCreate({ objectKey: presign.objectKey })
+
+    emit('uploaded')
+    open.value = false
+  } catch {
+    error.value = 'アバターの更新に失敗しました'
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <v-dialog v-model="open" max-width="480" persistent>
+    <v-card rounded="lg">
+      <v-card-title>アイコンを変更</v-card-title>
+
+      <v-card-text>
+        <v-alert
+          v-if="error"
+          type="error"
+          variant="tonal"
+          class="mb-4"
+          density="compact"
+        >
+          {{ error }}
+        </v-alert>
+
+        <v-file-input
+          v-model="selectedFile"
+          accept="image/png, image/jpeg"
+          label="画像を選択"
+          prepend-icon="mdi-camera"
+          variant="outlined"
+          density="comfortable"
+          class="mb-4"
+        />
+
+        <div v-if="imageSrc" class="avatar-cropper rounded-lg overflow-hidden">
+          <Cropper
+            ref="cropperRef"
+            :src="imageSrc"
+            :stencil-component="CircleStencil"
+            :stencil-props="{ aspectRatio: 1 }"
+            :canvas="{ maxWidth: MAX_OUTPUT_SIZE, maxHeight: MAX_OUTPUT_SIZE }"
+            image-restriction="stencil"
+          />
+        </div>
+        <v-sheet
+          v-else
+          color="grey-lighten-3"
+          rounded="lg"
+          class="d-flex align-center justify-center text-medium-emphasis"
+          height="240"
+        >
+          画像を選択してください
+        </v-sheet>
+      </v-card-text>
+
+      <v-card-actions class="px-4 pb-4">
+        <v-spacer />
+        <v-btn variant="text" :disabled="submitting" @click="open = false">
+          キャンセル
+        </v-btn>
+        <v-btn
+          color="primary"
+          variant="flat"
+          :loading="submitting"
+          :disabled="submitting || !imageSrc"
+          @click="save"
+        >
+          保存
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped>
+.avatar-cropper {
+  height: 320px;
+  background-color: rgb(var(--v-theme-surface-variant));
+}
+</style>

--- a/app/src/features/profile/AvatarEditDialog.vue
+++ b/app/src/features/profile/AvatarEditDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useDropZone, useFileDialog } from '@vueuse/core'
 import axios from 'axios'
 import { ref, watch } from 'vue'
 import { Cropper, CircleStencil } from 'vue-advanced-cropper'
@@ -10,15 +11,43 @@ import { api } from '@/api/client'
 const MAX_OUTPUT_SIZE = 512
 const MAX_UPLOAD_BYTES = 2 * 1024 * 1024
 const JPEG_QUALITY = 0.9
+const ACCEPTED_TYPES = ['image/png', 'image/jpeg']
 
 const open = defineModel<boolean>({ required: true })
 const emit = defineEmits<{ uploaded: [] }>()
 
 const cropperRef = ref<InstanceType<typeof Cropper>>()
+const dropZoneRef = ref<HTMLElement>()
 const selectedFile = ref<File>()
 const imageSrc = ref<string>()
 const submitting = ref(false)
 const error = ref<string>()
+
+// ドラッグ&ドロップとファイル選択ダイアログの 2 経路を 1 か所に集約する。
+const acceptFile = (file: File | null | undefined) => {
+  if (!file) return
+  if (!ACCEPTED_TYPES.includes(file.type)) {
+    error.value = 'PNG または JPEG を選択してください'
+    return
+  }
+  selectedFile.value = file
+}
+
+const {
+  open: openFileDialog,
+  onChange,
+  reset: resetFileDialog,
+} = useFileDialog({
+  accept: ACCEPTED_TYPES.join(','),
+  multiple: false,
+})
+onChange((files) => acceptFile(files?.[0]))
+
+const { isOverDropZone } = useDropZone(dropZoneRef, {
+  dataTypes: ACCEPTED_TYPES,
+  multiple: false,
+  onDrop: (files) => acceptFile(files?.[0]),
+})
 
 // 選択ファイルが変わるたびにプレビュー用 Object URL を張り替え、前の URL は解放する。
 watch(selectedFile, (file) => {
@@ -33,6 +62,7 @@ watch(open, (isOpen) => {
   imageSrc.value = undefined
   selectedFile.value = undefined
   error.value = undefined
+  resetFileDialog()
 })
 
 const cropToJpegBlob = (): Promise<Blob | null> =>
@@ -103,35 +133,51 @@ const save = async () => {
           {{ error }}
         </v-alert>
 
-        <v-file-input
-          v-model="selectedFile"
-          accept="image/png, image/jpeg"
-          label="画像を選択"
-          prepend-icon="mdi-camera"
-          variant="outlined"
-          density="comfortable"
-          class="mb-4"
-        />
+        <template v-if="imageSrc">
+          <div class="avatar-cropper rounded-lg overflow-hidden mb-2">
+            <Cropper
+              ref="cropperRef"
+              :src="imageSrc"
+              :stencil-component="CircleStencil"
+              :stencil-props="{ aspectRatio: 1 }"
+              :canvas="{
+                maxWidth: MAX_OUTPUT_SIZE,
+                maxHeight: MAX_OUTPUT_SIZE,
+              }"
+              image-restriction="stencil"
+            />
+          </div>
+          <div class="d-flex justify-center">
+            <v-btn
+              variant="text"
+              size="small"
+              prepend-icon="mdi-image-refresh-outline"
+              @click="openFileDialog()"
+            >
+              別の画像を選ぶ
+            </v-btn>
+          </div>
+        </template>
 
-        <div v-if="imageSrc" class="avatar-cropper rounded-lg overflow-hidden">
-          <Cropper
-            ref="cropperRef"
-            :src="imageSrc"
-            :stencil-component="CircleStencil"
-            :stencil-props="{ aspectRatio: 1 }"
-            :canvas="{ maxWidth: MAX_OUTPUT_SIZE, maxHeight: MAX_OUTPUT_SIZE }"
-            image-restriction="stencil"
-          />
-        </div>
-        <v-sheet
+        <div
           v-else
-          color="grey-lighten-3"
-          rounded="lg"
-          class="d-flex align-center justify-center text-medium-emphasis"
-          height="240"
+          ref="dropZoneRef"
+          class="drop-zone d-flex flex-column align-center justify-center ga-3 rounded-lg pa-6"
+          :class="{ 'drop-zone--active': isOverDropZone }"
+          role="button"
+          tabindex="0"
+          @click="openFileDialog()"
+          @keydown.enter="openFileDialog()"
+          @keydown.space.prevent="openFileDialog()"
         >
-          画像を選択してください
-        </v-sheet>
+          <v-icon size="48" color="primary">mdi-cloud-upload-outline</v-icon>
+          <div class="text-body-1 text-center">
+            画像をドラッグ＆ドロップ<br />またはクリックして選択
+          </div>
+          <div class="text-caption text-medium-emphasis">
+            PNG / JPEG ・ 2MB まで
+          </div>
+        </div>
       </v-card-text>
 
       <v-card-actions class="px-4 pb-4">
@@ -154,8 +200,23 @@ const save = async () => {
 </template>
 
 <style scoped>
+/* Vuetify には破線のドロップゾーン枠を表現するユーティリティが無いため、
+   ここだけテーマ変数を使った最小限の scoped CSS で実装する。 */
 .avatar-cropper {
   height: 320px;
   background-color: rgb(var(--v-theme-surface-variant));
+}
+
+.drop-zone {
+  min-height: 240px;
+  border: 2px dashed rgba(var(--v-theme-primary), 0.5);
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.drop-zone:hover,
+.drop-zone--active {
+  background-color: rgba(var(--v-theme-primary), 0.06);
+  border-color: rgb(var(--v-theme-primary));
 }
 </style>

--- a/app/src/features/profile/ProfileView.vue
+++ b/app/src/features/profile/ProfileView.vue
@@ -3,6 +3,7 @@ import axios from 'axios'
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import ArticleCard from '@/features/articles/ArticleCard.vue'
+import AvatarEditDialog from '@/features/profile/AvatarEditDialog.vue'
 import { api } from '@/api/client'
 import type {
   ServerArticleJSONResponse,
@@ -35,6 +36,7 @@ const listsLoading = ref(false)
 const listsError = ref<string | null>(null)
 
 const isEditing = ref(false)
+const avatarDialogOpen = ref(false)
 const bio = ref('')
 const submitting = ref(false)
 const maxLength = 200
@@ -124,6 +126,15 @@ const saveBio = async () => {
   }
 }
 
+// アバター更新後は presigned GET URL を更新したいだけなので、記事一覧は再取得せず
+// プロフィール本体だけを読み直す。
+const reloadProfile = async () => {
+  const targetId = await resolveTargetUserId()
+  if (targetId === null) return
+  const res = await api.api.profileDetail(targetId)
+  profile.value = res.data
+}
+
 // プロフィールではタグ絞り込みを持たないので、タグをクリックしたら
 // 記事一覧画面の絞り込みへ遷移させる。
 const goToTag = (tagName: string) => {
@@ -153,16 +164,28 @@ const goToTag = (tagName: string) => {
           <template v-else-if="profile">
             <v-card class="pa-6 mb-6" rounded="lg">
               <div class="d-flex ga-6 align-start">
-                <v-avatar size="96" color="indigo-lighten-1">
-                  <v-img
-                    v-if="profile.avatar_url"
-                    :src="profile.avatar_url"
-                    alt="アバター"
-                  />
-                  <v-icon v-else size="64" color="white">
-                    mdi-account-circle
-                  </v-icon>
-                </v-avatar>
+                <div class="d-flex flex-column align-center ga-2">
+                  <v-avatar size="96" color="indigo-lighten-1">
+                    <v-img
+                      v-if="profile.avatar_url"
+                      :src="profile.avatar_url"
+                      alt="アバター"
+                    />
+                    <v-icon v-else size="64" color="white">
+                      mdi-account-circle
+                    </v-icon>
+                  </v-avatar>
+                  <v-btn
+                    v-if="profile.is_owner"
+                    variant="text"
+                    color="primary"
+                    size="small"
+                    prepend-icon="mdi-camera"
+                    @click="avatarDialogOpen = true"
+                  >
+                    変更
+                  </v-btn>
+                </div>
 
                 <div class="flex-grow-1">
                   <h1 class="text-h5 font-weight-bold mb-2">
@@ -215,6 +238,12 @@ const goToTag = (tagName: string) => {
                 </div>
               </div>
             </v-card>
+
+            <AvatarEditDialog
+              v-if="profile.is_owner"
+              v-model="avatarDialogOpen"
+              @uploaded="reloadProfile"
+            />
 
             <v-tabs v-model="activeTab" color="primary" class="mb-4">
               <v-tab value="articles">投稿した記事</v-tab>

--- a/app/src/features/profile/ProfileView.vue
+++ b/app/src/features/profile/ProfileView.vue
@@ -151,7 +151,7 @@ const goToTag = (tagName: string) => {
   <v-sheet color="grey-lighten-4" min-height="100%">
     <v-container class="py-8">
       <v-row justify="center">
-        <v-col cols="12" sm="10" md="8">
+        <v-col cols="12" sm="10">
           <v-alert
             v-if="error"
             type="error"

--- a/app/src/features/profile/ProfileView.vue
+++ b/app/src/features/profile/ProfileView.vue
@@ -126,6 +126,11 @@ const saveBio = async () => {
   }
 }
 
+// アバターは編集モードのときだけ変更できる（オーバーレイのカメラから開く）。
+const onAvatarClick = () => {
+  if (isEditing.value) avatarDialogOpen.value = true
+}
+
 // アバター更新後は presigned GET URL を更新したいだけなので、記事一覧は再取得せず
 // プロフィール本体だけを読み直す。
 const reloadProfile = async () => {
@@ -164,7 +169,11 @@ const goToTag = (tagName: string) => {
           <template v-else-if="profile">
             <v-card class="pa-6 mb-6" rounded="lg">
               <div class="d-flex ga-6 align-start">
-                <div class="d-flex flex-column align-center ga-2">
+                <div
+                  class="avatar-edit"
+                  :class="{ 'avatar-edit--active': isEditing }"
+                  @click="onAvatarClick"
+                >
                   <v-avatar size="96" color="indigo-lighten-1">
                     <v-img
                       v-if="profile.avatar_url"
@@ -175,16 +184,9 @@ const goToTag = (tagName: string) => {
                       mdi-account-circle
                     </v-icon>
                   </v-avatar>
-                  <v-btn
-                    v-if="profile.is_owner"
-                    variant="text"
-                    color="primary"
-                    size="small"
-                    prepend-icon="mdi-camera"
-                    @click="avatarDialogOpen = true"
-                  >
-                    変更
-                  </v-btn>
+                  <div v-if="isEditing" class="avatar-edit__overlay">
+                    <v-icon color="white">mdi-camera</v-icon>
+                  </div>
                 </div>
 
                 <div class="flex-grow-1">
@@ -192,21 +194,9 @@ const goToTag = (tagName: string) => {
                     {{ profile.name }}
                   </h1>
 
-                  <template v-if="!isEditing">
-                    <p class="text-body-2 text-medium-emphasis mb-2">
-                      {{ profile.bio || '自己紹介はまだありません' }}
-                    </p>
-                    <v-btn
-                      v-if="profile.is_owner"
-                      variant="text"
-                      color="primary"
-                      size="small"
-                      prepend-icon="mdi-pencil"
-                      @click="isEditing = true"
-                    >
-                      編集
-                    </v-btn>
-                  </template>
+                  <p v-if="!isEditing" class="text-body-2 text-medium-emphasis">
+                    {{ profile.bio || '自己紹介はまだありません' }}
+                  </p>
 
                   <template v-else>
                     <v-textarea
@@ -222,20 +212,32 @@ const goToTag = (tagName: string) => {
                       rows="3"
                       class="mb-2"
                     />
-                    <v-btn
-                      color="primary"
-                      class="mr-2"
-                      :loading="submitting"
-                      :disabled="submitting"
-                      @click="saveBio"
-                    >
-                      完了
-                    </v-btn>
-                    <v-btn variant="text" @click="isEditing = false">
-                      キャンセル
-                    </v-btn>
+                    <div class="d-flex ga-2">
+                      <v-btn
+                        color="primary"
+                        :loading="submitting"
+                        :disabled="submitting"
+                        @click="saveBio"
+                      >
+                        完了
+                      </v-btn>
+                      <v-btn variant="text" @click="isEditing = false">
+                        キャンセル
+                      </v-btn>
+                    </div>
                   </template>
                 </div>
+
+                <v-btn
+                  v-if="profile.is_owner && !isEditing"
+                  variant="text"
+                  color="primary"
+                  size="small"
+                  prepend-icon="mdi-pencil"
+                  @click="isEditing = true"
+                >
+                  編集
+                </v-btn>
               </div>
             </v-card>
 
@@ -303,3 +305,32 @@ const goToTag = (tagName: string) => {
     </v-container>
   </v-sheet>
 </template>
+
+<style scoped>
+/* 編集モード時にアバター上へカメラを重ねる。Vuetify にアバター用の
+   オーバーレイ表現が無いため、ここだけ最小限の scoped CSS で実装する。 */
+.avatar-edit {
+  position: relative;
+  display: inline-flex;
+  border-radius: 50%;
+}
+
+.avatar-edit--active {
+  cursor: pointer;
+}
+
+.avatar-edit__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.45);
+  transition: background-color 0.2s ease;
+}
+
+.avatar-edit--active:hover .avatar-edit__overlay {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+</style>

--- a/app/src/features/profile/ProfileView.vue
+++ b/app/src/features/profile/ProfileView.vue
@@ -133,11 +133,19 @@ const onAvatarClick = () => {
 
 // アバター更新後は presigned GET URL を更新したいだけなので、記事一覧は再取得せず
 // プロフィール本体だけを読み直す。
+// アップロード自体は成功しているので、再取得失敗ではエラーページへ遷移させず
+// （skipGlobalErrorHandler）、画面内のアラートで知らせるにとどめる。
 const reloadProfile = async () => {
-  const targetId = await resolveTargetUserId()
-  if (targetId === null) return
-  const res = await api.api.profileDetail(targetId)
-  profile.value = res.data
+  try {
+    const targetId = await resolveTargetUserId()
+    if (targetId === null) return
+    const res = await api.api.profileDetail(targetId, {
+      skipGlobalErrorHandler: true,
+    })
+    profile.value = res.data
+  } catch {
+    error.value = 'アイコンは更新されましたが、表示の再取得に失敗しました'
+  }
 }
 
 // プロフィールではタグ絞り込みを持たないので、タグをクリックしたら
@@ -172,7 +180,12 @@ const goToTag = (tagName: string) => {
                 <div
                   class="avatar-edit"
                   :class="{ 'avatar-edit--active': isEditing }"
+                  :role="isEditing ? 'button' : undefined"
+                  :tabindex="isEditing ? 0 : undefined"
+                  :aria-label="isEditing ? 'アイコンを変更' : undefined"
                   @click="onAvatarClick"
+                  @keydown.enter="onAvatarClick"
+                  @keydown.space.prevent="onAvatarClick"
                 >
                   <v-avatar size="96" color="indigo-lighten-1">
                     <v-img


### PR DESCRIPTION
## 概要

自分のプロフィール（profile/me）でアイコン画像を変更・追加できるUIを追加しました。あわせて、アイコン変更と自己紹介編集の入口を **統一編集モード** にまとめ、表示状態のレイアウトを他人プロフィールと共通化しています。

バックエンドの presign アップロード基盤（`/api/profile/avatar/presign` → presigned PUT → `/api/profile/avatar/complete`）は実装済みのため、本PRはフロントエンドのUIのみです。

## 変更点

### アバター画像のクロップ＆アップロード（`AvatarEditDialog.vue` 新規）
- `vue-advanced-cropper` を導入し、円形ステンシルでクロップ
- クロップ結果を **512px四方のJPEGに正規化** し、サーバ制約（2MB以下・png/jpeg のみ）をクライアント側で確実に満たす
- 画像選択は `@vueuse/core` の `useDropZone` + `useFileDialog` による **ドラッグ&ドロップ対応のドロップゾーン**（隠しinputや余分なref/フラグ不要）
- presigned URL へは素の axios で直接 PUT（api クライアントの Authorization が署名と干渉するのを回避）
- 二重送信ガード（`submitting` の早期 return ＋ `:loading`/`:disabled`）

### 統一編集モード（`ProfileView.vue`）
- 表示状態は **他人プロフィールと完全に共通**のレイアウト（アバター＋名前＋bio）
- オーナーのときだけカード右上に「編集」ボタンを1つ表示 → 押すと編集モードへ
- 編集モードではアバターにカメラオーバーレイ（クリックで変更ダイアログ）、bio は入力欄、直下に完了/キャンセル
- 入口を1か所に集約し、ボタンがフロー内でガタつく問題を解消

## 確認

- `npm run lint`（type-check + eslint）通過
- `npm run build-only` 成功
- 自己プロフィールの右上に「編集」ボタン　これを押すことで編集モードに移行
- <img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/7924f70d-6831-4d63-8213-dda1ca8d0e37" />
- 統一編集モード 自己紹介の編集と　カメラアイコンで画像アップロード可能
- <img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/84a4fd9d-07c9-4e99-ae59-ec0183a24ca1" />
- アイコン画像のアップロードがドロップエリアで実装
- <img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/9fbdd4bd-f50e-4d41-aeb7-8e9f0fdf83fb" />
- トリミング可能
- <img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/fe84f6f9-8343-4e93-a29d-daab87951598" />





## 補足
- `app/src/api/generated/**` は変更なし（既存の生成クライアントのメソッドを利用）