### PR TITLE
回答の回答にもベストアンサーを可能にする

### DIFF
--- a/api/internal/reply/repository/set_best_answer.go
+++ b/api/internal/reply/repository/set_best_answer.go
@@ -19,52 +19,73 @@ func (r *Repository) SetBestAnswer(ctx context.Context, replyID, userID int64) e
 	}
 	defer tx.Rollback()
 
-	const fetchReplyQuery = `
-		SELECT kind, parent_id
-		FROM replies
-		WHERE id = $1
+	// 1. 指定された reply が存在し、answer であることを確認し、同時にルートの質問者 ID を取得する。
+	// ネスト制限が最大 2 なので、再帰的に遡るか、直接 root を特定する。
+	// ここでは汎用性のために Recursive CTE を使用してルート投稿（parent_id IS NULL）を見つける。
+	const findRootQuery = `
+		WITH RECURSIVE root_path AS (
+			SELECT id, parent_id, kind, user_id, 1 as depth
+			FROM replies
+			WHERE id = $1
+			UNION ALL
+			SELECT r.id, r.parent_id, r.kind, r.user_id, rp.depth + 1
+			FROM replies r
+			JOIN root_path rp ON r.id = rp.parent_id
+		)
+		SELECT id, kind, user_id FROM root_path WHERE parent_id IS NULL
 	`
-	var kind reply.Kind
-	var parentID sql.NullInt64
-	err = tx.QueryRowContext(ctx, fetchReplyQuery, replyID).Scan(&kind, &parentID)
+
+	var rootID int64
+	var rootKind reply.Kind
+	var questionUserID int64
+
+	// まず指定された reply 自体の kind をチェック
+	const fetchKindQuery = `SELECT kind FROM replies WHERE id = $1`
+	var targetKind reply.Kind
+	err = tx.QueryRowContext(ctx, fetchKindQuery, replyID).Scan(&targetKind)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrReplyNotFound
 	}
 	if err != nil {
 		return err
 	}
-	if kind != reply.KindAnswer {
-		return ErrNotAnswer
-	}
-	if !parentID.Valid {
+	if targetKind != reply.KindAnswer {
 		return ErrNotAnswer
 	}
 
-	const fetchParentQuery = `
-		SELECT kind, user_id
-		FROM replies
-		WHERE id = $1
-	`
-	var parentKind reply.Kind
-	var questionUserID int64
-	err = tx.QueryRowContext(ctx, fetchParentQuery, parentID.Int64).Scan(&parentKind, &questionUserID)
+	// ルートを特定して権限チェック
+	err = tx.QueryRowContext(ctx, findRootQuery, replyID).Scan(&rootID, &rootKind, &questionUserID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return ErrParentNotFound
+		// 自分がルートの場合は親がいないのでここに来る可能性があるが、KindAnswer なのであり得ないはず。
+		return ErrNotAnswer
 	}
 	if err != nil {
 		return err
 	}
-	if parentKind != reply.KindQuestion {
-		return ErrNotAnswer
+
+	if rootKind != reply.KindQuestion {
+		return ErrNotAnswer // 質問スレッド以外でのベストアンサーは不可
 	}
 
 	if questionUserID != userID {
 		return ErrNotQuestionAuthor
 	}
 
-	const checkBestQuery = `SELECT EXISTS(SELECT 1 FROM replies WHERE parent_id = $1 AND is_best = TRUE)`
+	// 2. スレッド内のいずれかの返信にすでにベストアンサーが設定されていないか確認する。
+	// ルート質問 ID を起点に、その配下の全子孫（再帰）の中で is_best = TRUE のものを探す。
+	const checkThreadBestQuery = `
+		WITH RECURSIVE thread_members AS (
+			SELECT id FROM replies WHERE id = $1
+			UNION ALL
+			SELECT r.id FROM replies r
+			JOIN thread_members tm ON r.parent_id = tm.id
+		)
+		SELECT EXISTS (
+			SELECT 1 FROM replies WHERE id IN (SELECT id FROM thread_members) AND is_best = TRUE
+		)
+	`
 	var hasBest bool
-	err = tx.QueryRowContext(ctx, checkBestQuery, parentID.Int64).Scan(&hasBest)
+	err = tx.QueryRowContext(ctx, checkThreadBestQuery, rootID).Scan(&hasBest)
 	if err != nil {
 		return err
 	}

--- a/api/internal/reply/repository/set_best_answer.go
+++ b/api/internal/reply/repository/set_best_answer.go
@@ -19,54 +19,45 @@ func (r *Repository) SetBestAnswer(ctx context.Context, replyID, userID int64) e
 	}
 	defer tx.Rollback()
 
-	// 1. 指定された reply が存在し、answer であることを確認し、同時にルートの質問者 ID を取得する。
-	// ネスト制限が最大 2 なので、再帰的に遡るか、直接 root を特定する。
-	// ここでは汎用性のために Recursive CTE を使用してルート投稿（parent_id IS NULL）を見つける。
+	// 1. 指定された reply が存在し、answer であることを確認し、同時にルートの質問者を特定する。
+	// クエリ数を削減するため、Recursive CTE でターゲットの kind を引き継ぎつつルート（parent_id IS NULL）を特定する。
 	const findRootQuery = `
 		WITH RECURSIVE root_path AS (
-			SELECT id, parent_id, kind, user_id, 1 as depth
+			SELECT id, parent_id, kind, user_id, kind as target_kind
 			FROM replies
 			WHERE id = $1
 			UNION ALL
-			SELECT r.id, r.parent_id, r.kind, r.user_id, rp.depth + 1
+			SELECT r.id, r.parent_id, r.kind, r.user_id, rp.target_kind
 			FROM replies r
 			JOIN root_path rp ON r.id = rp.parent_id
 		)
-		SELECT id, kind, user_id FROM root_path WHERE parent_id IS NULL
+		SELECT target_kind, id, kind, user_id FROM root_path WHERE parent_id IS NULL
 	`
 
+	var targetKind reply.Kind
 	var rootID int64
 	var rootKind reply.Kind
 	var questionUserID int64
 
-	// まず指定された reply 自体の kind をチェック
-	const fetchKindQuery = `SELECT kind FROM replies WHERE id = $1`
-	var targetKind reply.Kind
-	err = tx.QueryRowContext(ctx, fetchKindQuery, replyID).Scan(&targetKind)
+	err = tx.QueryRowContext(ctx, findRootQuery, replyID).Scan(&targetKind, &rootID, &rootKind, &questionUserID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrReplyNotFound
 	}
 	if err != nil {
 		return err
 	}
+
+	// ターゲットが回答であることをチェック
 	if targetKind != reply.KindAnswer {
 		return ErrNotAnswer
 	}
 
-	// ルートを特定して権限チェック
-	err = tx.QueryRowContext(ctx, findRootQuery, replyID).Scan(&rootID, &rootKind, &questionUserID)
-	if errors.Is(err, sql.ErrNoRows) {
-		// 自分がルートの場合は親がいないのでここに来る可能性があるが、KindAnswer なのであり得ないはず。
-		return ErrNotAnswer
-	}
-	if err != nil {
-		return err
-	}
-
+	// ルートが質問であることをチェック
 	if rootKind != reply.KindQuestion {
 		return ErrNotAnswer // 質問スレッド以外でのベストアンサーは不可
 	}
 
+	// 権限チェック
 	if questionUserID != userID {
 		return ErrNotQuestionAuthor
 	}

--- a/api/internal/reply/repository/unset_best_answer.go
+++ b/api/internal/reply/repository/unset_best_answer.go
@@ -19,52 +19,45 @@ func (r *Repository) UnsetBestAnswer(ctx context.Context, replyID, userID int64)
 	}
 	defer tx.Rollback()
 
-	// 1. 指定された reply が存在し、answer かつベストアンサーであることを確認する。
-	const fetchReplyQuery = `
-		SELECT kind, is_best
-		FROM replies
-		WHERE id = $1
+	// 1. 指定された reply が存在し、ルートの質問者を特定して権限チェックを行う。
+	// クエリ数を削減するため、Recursive CTE でターゲットの情報を引き継ぎつつルート（parent_id IS NULL）を特定する。
+	const findRootQuery = `
+		WITH RECURSIVE root_path AS (
+			SELECT id, parent_id, kind, user_id, kind as target_kind, is_best as target_is_best
+			FROM replies
+			WHERE id = $1
+			UNION ALL
+			SELECT r.id, r.parent_id, r.kind, r.user_id, rp.target_kind, rp.target_is_best
+			FROM replies r
+			JOIN root_path rp ON r.id = rp.parent_id
+		)
+		SELECT target_kind, target_is_best, kind, user_id FROM root_path WHERE parent_id IS NULL
 	`
-	var kind reply.Kind
-	var isBest bool
-	err = tx.QueryRowContext(ctx, fetchReplyQuery, replyID).Scan(&kind, &isBest)
+
+	var targetKind reply.Kind
+	var targetIsBest bool
+	var rootKind reply.Kind
+	var questionUserID int64
+	err = tx.QueryRowContext(ctx, findRootQuery, replyID).Scan(&targetKind, &targetIsBest, &rootKind, &questionUserID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrReplyNotFound
 	}
 	if err != nil {
 		return err
 	}
-	if kind != reply.KindAnswer {
+
+	// ターゲットの状態チェック
+	if targetKind != reply.KindAnswer {
 		return ErrNotAnswer
 	}
-	if !isBest {
+	if !targetIsBest {
 		return ErrNotBestAnswer
 	}
 
-	// 2. ルートの質問者を特定して権限チェックを行う。
-	const findRootQuery = `
-		WITH RECURSIVE root_path AS (
-			SELECT id, parent_id, kind, user_id
-			FROM replies
-			WHERE id = $1
-			UNION ALL
-			SELECT r.id, r.parent_id, r.kind, r.user_id
-			FROM replies r
-			JOIN root_path rp ON r.id = rp.parent_id
-		)
-		SELECT kind, user_id FROM root_path WHERE parent_id IS NULL
-	`
-	var rootKind reply.Kind
-	var questionUserID int64
-	err = tx.QueryRowContext(ctx, findRootQuery, replyID).Scan(&rootKind, &questionUserID)
-	if err != nil {
-		return err
-	}
-
+	// ルートの整合性と権限チェック
 	if rootKind != reply.KindQuestion {
 		return ErrNotAnswer
 	}
-
 	if questionUserID != userID {
 		return ErrNotQuestionAuthor
 	}

--- a/api/internal/reply/repository/unset_best_answer.go
+++ b/api/internal/reply/repository/unset_best_answer.go
@@ -19,15 +19,15 @@ func (r *Repository) UnsetBestAnswer(ctx context.Context, replyID, userID int64)
 	}
 	defer tx.Rollback()
 
+	// 1. 指定された reply が存在し、answer かつベストアンサーであることを確認する。
 	const fetchReplyQuery = `
-		SELECT kind, parent_id, is_best
+		SELECT kind, is_best
 		FROM replies
 		WHERE id = $1
 	`
 	var kind reply.Kind
-	var parentID sql.NullInt64
 	var isBest bool
-	err = tx.QueryRowContext(ctx, fetchReplyQuery, replyID).Scan(&kind, &parentID, &isBest)
+	err = tx.QueryRowContext(ctx, fetchReplyQuery, replyID).Scan(&kind, &isBest)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrReplyNotFound
 	}
@@ -40,25 +40,28 @@ func (r *Repository) UnsetBestAnswer(ctx context.Context, replyID, userID int64)
 	if !isBest {
 		return ErrNotBestAnswer
 	}
-	if !parentID.Valid {
-		return ErrNotAnswer
-	}
 
-	const fetchParentQuery = `
-		SELECT kind, user_id
-		FROM replies
-		WHERE id = $1
+	// 2. ルートの質問者を特定して権限チェックを行う。
+	const findRootQuery = `
+		WITH RECURSIVE root_path AS (
+			SELECT id, parent_id, kind, user_id
+			FROM replies
+			WHERE id = $1
+			UNION ALL
+			SELECT r.id, r.parent_id, r.kind, r.user_id
+			FROM replies r
+			JOIN root_path rp ON r.id = rp.parent_id
+		)
+		SELECT kind, user_id FROM root_path WHERE parent_id IS NULL
 	`
-	var parentKind reply.Kind
+	var rootKind reply.Kind
 	var questionUserID int64
-	err = tx.QueryRowContext(ctx, fetchParentQuery, parentID.Int64).Scan(&parentKind, &questionUserID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return ErrParentNotFound
-	}
+	err = tx.QueryRowContext(ctx, findRootQuery, replyID).Scan(&rootKind, &questionUserID)
 	if err != nil {
 		return err
 	}
-	if parentKind != reply.KindQuestion {
+
+	if rootKind != reply.KindQuestion {
 		return ErrNotAnswer
 	}
 

--- a/app/src/features/replies/ReplySection.vue
+++ b/app/src/features/replies/ReplySection.vue
@@ -146,16 +146,26 @@ const hiddenDescendantCountByReplyId = computed(() => {
   return result
 })
 
-// 各リプライについて、その親が質問（kind=question）なら親の user_id を記録する Map。
+// 各リプライについて、そのスレッドのルートが質問（kind=question）ならルートの user_id を記録する Map。
+// 2階層目以降の回答に対しても「ベストアンサーに選ぶ」権限を確認できるようにするため、
+// 親だけでなくルートまで遡って判定する。
 // key = 子の reply.id, value = 質問の user_id。
 const questionAuthorByReplyId = computed(() => {
   const map = new Map<number, number>()
   const replyMap = new Map(replies.value.map((r) => [r.id, r]))
+
   for (const r of replies.value) {
-    if (r.parent_id == null) continue
-    const parent = replyMap.get(r.parent_id)
-    if (parent && parent.kind === 'question') {
-      map.set(r.id, parent.user_id)
+    let current = r
+    // 親を辿ってルート（parent_id == null）を探す
+    while (current.parent_id != null) {
+      const parent = replyMap.get(current.parent_id)
+      if (!parent) break
+      current = parent
+    }
+
+    // ルートが質問であれば、その投稿者 ID を保持する
+    if (current.kind === 'question') {
+      map.set(r.id, current.user_id)
     }
   }
   return map


### PR DESCRIPTION
## やったこと
- 
-  1. バックエンド (Go)
   - SetBestAnswer の修正 (api/internal/reply/repository/set_best_answer.go):
       - 再帰クエリ (Recursive CTE)
         を使用して、指定された返信からスレッドのルート投稿（質問）を特定するようにしました
         。
       - ルート投稿が「質問」であり、かつ実行者がその質問者であることを検証するロジックに変
         更しました。
       - スレッド全体（ルート質問の全子孫）を対象に、すでにベストアンサーが設定されていない
         かチェックするように強化しました。
   - UnsetBestAnswer の修正 (api/internal/reply/repository/unset_best_answer.go):
       - SetBestAnswer と同様に、ルートを遡って質問者権限を確認するロジックに修正しました。

  2. フロントエンド (Vue)
   - ReplySection.vue の修正:
       - questionAuthorByReplyId 計算プロパティを更新しました。
       - 各返信から parent_id を遡ってルートの質問者を特定し、その投稿者IDを Map
         に登録するようにしました。これにより、2階層目（回答への回答）に対しても質問者がベス
         トアンサーを選択できる権限が正しく伝播します。


## 動作確認
<img width="1582" height="846" alt="image" src="https://github.com/user-attachments/assets/412dbb1f-eac6-4632-906b-48421afc639f" />

Closes #277