### PR TITLE
ベストアンサー獲得回数

### DIFF
--- a/api/internal/article/repository/list_profile_articles.go
+++ b/api/internal/article/repository/list_profile_articles.go
@@ -28,6 +28,30 @@ func (r *Repository) ListArticlesByAuthor(ctx context.Context, authorID int64, v
 	return scanArticleList(rows)
 }
 
+// ListBestAnswerArticles は userID の回答がベストアンサーに選ばれた記事を新しい順に返す。
+// viewerID は閲覧者で、各記事の liked_by_me 判定に使う（userID とは別概念）。
+func (r *Repository) ListBestAnswerArticles(ctx context.Context, userID int64, viewerID int64) ([]article.Article, error) {
+	if r == nil || r.db == nil {
+		return nil, errors.New("article repository is not configured")
+	}
+
+	query := articleListSelectFrom + `
+		WHERE EXISTS (
+			SELECT 1 FROM replies r
+			WHERE r.article_id = a.id AND r.user_id = $2 AND r.is_best = TRUE
+		)
+		ORDER BY a.created_at DESC, a.id DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, viewerID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanArticleList(rows)
+}
+
 // ListLikedArticles は likerID がいいねした記事を「いいねした順」で返す。
 // viewerID は閲覧者で、各記事の liked_by_me 判定に使う（likerID とは別概念）。
 func (r *Repository) ListLikedArticles(ctx context.Context, likerID int64, viewerID int64) ([]article.Article, error) {

--- a/api/internal/profile/handler/get_user_articles.go
+++ b/api/internal/profile/handler/get_user_articles.go
@@ -40,6 +40,36 @@ func (h *Handler) getUserArticlesHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, articlehandler.NewListArticlesJSONResponse(articles))
 }
 
+// getUserBestAnswerArticlesHandler godoc
+//
+//	@Summary		List articles where user's reply was marked as best answer
+//	@Description	指定ユーザーの回答がベストアンサーに選ばれた記事一覧を新しい順に取得する
+//	@Tags			profile
+//	@Produce		json
+//	@Param			user_id	path		int	true	"User ID"
+//	@Success		200		{object}	handler.ListArticlesJSONResponse
+//	@Failure		400		{object}	ErrorResponse
+//	@Failure		500		{object}	ErrorResponse
+//	@Router			/api/profile/{user_id}/best-answer-articles [get]
+func (h *Handler) getUserBestAnswerArticlesHandler(c *gin.Context) {
+	userID, err := strconv.ParseInt(c.Param("user_id"), 10, 64)
+	if err != nil || userID <= 0 {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Message: "invalid user_id"})
+		return
+	}
+
+	viewerID, _ := auth.OptionalUserID(c)
+
+	articles, err := h.articleRepo.ListBestAnswerArticles(c.Request.Context(), userID, viewerID)
+	if err != nil {
+		log.Printf("list user best answer articles: %v", err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Message: "failed to list best answer articles"})
+		return
+	}
+
+	c.JSON(http.StatusOK, articlehandler.NewListArticlesJSONResponse(articles))
+}
+
 // getUserLikedArticlesHandler godoc
 //
 //	@Summary		List articles liked by a user

--- a/api/internal/profile/handler/get_user_profile.go
+++ b/api/internal/profile/handler/get_user_profile.go
@@ -19,6 +19,7 @@ type ProfileJSON struct {
 	Name             string     `json:"name"`
 	Bio              string     `json:"bio"`
 	AvatarURL        string     `json:"avatar_url"`
+	BestAnswerCount  int64      `json:"best_answer_count"`
 	ProfileCreatedAt *time.Time `json:"profile_created_at"`
 	ProfileUpdatedAt *time.Time `json:"profile_updated_at"`
 	IsOwner          bool       `json:"is_owner"`
@@ -96,6 +97,7 @@ func newProfileJSON(p profile.Profile, isOwner bool, avatarURL string) ProfileJS
 		Name:             p.User.Name,
 		Bio:              p.UserProfile.Bio.String,
 		AvatarURL:        avatarURL,
+		BestAnswerCount:  p.BestAnswerCount,
 		ProfileCreatedAt: profileCreatedAt,
 		ProfileUpdatedAt: profileUpdatedAt,
 		IsOwner:          isOwner,

--- a/api/internal/profile/handler/handler.go
+++ b/api/internal/profile/handler/handler.go
@@ -19,6 +19,7 @@ func (h *Handler) RegisterRoutes(router gin.IRouter, authRouter gin.IRouter) {
 	router.GET("/profile/:user_id", h.getUserProfileHandler)
 	router.GET("/profile/:user_id/articles", h.getUserArticlesHandler)
 	router.GET("/profile/:user_id/liked-articles", h.getUserLikedArticlesHandler)
+	router.GET("/profile/:user_id/best-answer-articles", h.getUserBestAnswerArticlesHandler)
 	authRouter.PUT("/profile/bio", h.updateBioHandler)
 	authRouter.POST("/profile/avatar/presign", h.presignAvatarHandler)
 	authRouter.POST("/profile/avatar/complete", h.avatarUploadCompleteHandler)

--- a/api/internal/profile/profile.go
+++ b/api/internal/profile/profile.go
@@ -23,8 +23,9 @@ type UserProfile struct {
 }
 
 type Profile struct {
-	User        User
-	UserProfile UserProfile
+	User             User
+	UserProfile      UserProfile
+	BestAnswerCount  int64
 }
 
 const maxBioLength = 200

--- a/api/internal/profile/profile.go
+++ b/api/internal/profile/profile.go
@@ -23,9 +23,9 @@ type UserProfile struct {
 }
 
 type Profile struct {
-	User             User
-	UserProfile      UserProfile
-	BestAnswerCount  int64
+	User            User
+	UserProfile     UserProfile
+	BestAnswerCount int64
 }
 
 const maxBioLength = 200

--- a/api/internal/profile/repository/get_profile.go
+++ b/api/internal/profile/repository/get_profile.go
@@ -23,7 +23,12 @@ func (r *Repository) FindByID(ctx context.Context, id int64) (profile.Profile, e
             user_profiles.object_key,
             COALESCE(user_profiles.is_uploaded, false),
             user_profiles.created_at,
-            user_profiles.updated_at
+            user_profiles.updated_at,
+            COALESCE(
+                (SELECT COUNT(*) FROM replies
+                 WHERE replies.is_best = TRUE AND replies.user_id = $1),
+                0
+            )
         FROM users
         LEFT JOIN user_profiles
             ON user_profiles.user_id = users.id
@@ -38,6 +43,7 @@ func (r *Repository) FindByID(ctx context.Context, id int64) (profile.Profile, e
 		&p.UserProfile.IsUploaded,
 		&p.UserProfile.CreatedAt,
 		&p.UserProfile.UpdatedAt,
+		&p.BestAnswerCount,
 	)
 
 	if err != nil {

--- a/api/migrations/20260528000000_add_best_answer_index.down.sql
+++ b/api/migrations/20260528000000_add_best_answer_index.down.sql
@@ -1,1 +1,1 @@
-DROP INDEX idx_replies_user_best;
+DROP INDEX IF EXISTS idx_replies_user_best;

--- a/api/migrations/20260528000000_add_best_answer_index.down.sql
+++ b/api/migrations/20260528000000_add_best_answer_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_replies_user_best;

--- a/api/migrations/20260528000000_add_best_answer_index.up.sql
+++ b/api/migrations/20260528000000_add_best_answer_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_replies_user_best ON replies(user_id, article_id) WHERE is_best = TRUE;

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -266,6 +266,8 @@ definitions:
     properties:
       avatar_url:
         type: string
+      best_answer_count:
+        type: integer
       bio:
         type: string
       id:

--- a/api/swagger/openapi.yml
+++ b/api/swagger/openapi.yml
@@ -760,6 +760,33 @@ paths:
       summary: List articles posted by a user
       tags:
       - profile
+  /api/profile/{user_id}/best-answer-articles:
+    get:
+      description: 指定ユーザーの回答がベストアンサーに選ばれた記事一覧を新しい順に取得する
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.listArticlesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/server.profileErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/server.profileErrorResponse'
+      summary: List articles where user's reply was marked as best answer
+      tags:
+      - profile
   /api/profile/{user_id}/liked-articles:
     get:
       description: 指定ユーザーがいいねした記事一覧をいいねした順に取得する

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -792,6 +792,47 @@
                 }
             }
         },
+        "/api/profile/{user_id}/best-answer-articles": {
+            "get": {
+                "description": "指定ユーザーの回答がベストアンサーに選ばれた記事一覧を新しい順に取得する",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "List articles where user's reply was marked as best answer",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.listArticlesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/server.profileErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/server.profileErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/profile/{user_id}/liked-articles": {
             "get": {
                 "description": "指定ユーザーがいいねした記事一覧をいいねした順に取得する",

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -1376,6 +1376,9 @@
                 "avatar_url": {
                     "type": "string"
                 },
+                "best_answer_count": {
+                    "type": "integer"
+                },
                 "bio": {
                     "type": "string"
                 },

--- a/app/src/api/generated/apiSchema.ts
+++ b/app/src/api/generated/apiSchema.ts
@@ -155,6 +155,7 @@ export interface ServerProfileErrorResponse {
 
 export interface ServerProfileJSON {
   avatar_url?: string;
+  best_answer_count?: number;
   bio?: string;
   id?: number;
   is_owner?: boolean;
@@ -620,6 +621,25 @@ export class Api<
     profileArticlesList: (userId: number, params: RequestParams = {}) =>
       this.request<ServerListArticlesResponse, ServerProfileErrorResponse>({
         path: `/api/profile/${userId}/articles`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description 指定ユーザーの回答がベストアンサーに選ばれた記事一覧を新しい順に取得する
+     *
+     * @tags profile
+     * @name ProfileBestAnswerArticlesList
+     * @summary List articles where user's reply was marked as best answer
+     * @request GET:/api/profile/{user_id}/best-answer-articles
+     */
+    profileBestAnswerArticlesList: (
+      userId: number,
+      params: RequestParams = {},
+    ) =>
+      this.request<ServerListArticlesResponse, ServerProfileErrorResponse>({
+        path: `/api/profile/${userId}/best-answer-articles`,
         method: "GET",
         format: "json",
         ...params,


### PR DESCRIPTION
## やったこと
1. プロフィールにベストアンサー獲得回数を追加
- Profile 構造体に BestAnswerCount フィールドを追加
- SQL に「このユーザーのベストアンサーは何件か」を数えるクエリを追加
- API レスポンスに best_answer_count を含めるようにした
2. ベストアンサー記事一覧のエンドポイントを新規作成
- 「このユーザーがベストアンサーに選ばれた記事」を取得するメソッドを追加
- そのメソッドを呼ぶハンドラを追加
- /profile/:user_id/best-answer-articles のルートを登録
3. 検索を速くするためのインデックスを追加
- replies テーブルに部分インデックスを作成（is_best = TRUE の行だけ対象）

## 動作確認
<img width="1819" height="995" alt="image" src="https://github.com/user-attachments/assets/7a4370ec-ca0f-4b66-b3f9-0f1d7d820f21" />
<img width="1008" height="1043" alt="image" src="https://github.com/user-attachments/assets/6f1227d3-58a7-4b4a-876a-80c51222af3a" />

ベストアンサーの回数
<img width="1822" height="915" alt="image" src="https://github.com/user-attachments/assets/838f9316-fa08-46b4-8c22-b2a328a7543b" />




Closes #283