### PR TITLE
階層表示制限4階層目まで

### DIFF
--- a/api/internal/reply/repository/create_reply.go
+++ b/api/internal/reply/repository/create_reply.go
@@ -9,7 +9,7 @@ import (
 	"github.com/lib/pq"
 )
 
-const maxReplyDepth = 2
+const maxReplyDepth = 3
 
 func (r *Repository) Create(ctx context.Context, articleID int64, userID int64, parentID *int64, kind reply.Kind, body string) (reply.Reply, error) {
 	if r == nil || r.db == nil {

--- a/app/src/features/replies/ReplyThread.vue
+++ b/app/src/features/replies/ReplyThread.vue
@@ -79,7 +79,7 @@ const handleBestUpdated = (replyId: number, isBest: boolean) => {
 <template>
   <div class="d-flex flex-column ga-3">
     <!-- 
-      ✨ 変更箇所: depth が 3 (4階層目) のときは、
+      ✨ 変更箇所: depth が 3 以上 (4階層目以降) のときは、
       ログイン状態に関わらず can-reply を強制的に false にして返信ボタンを消します。
     -->
     <ReplyItem
@@ -92,7 +92,7 @@ const handleBestUpdated = (replyId: number, isBest: boolean) => {
       @best-updated="handleBestUpdated"
     />
 
-    <!-- 安全対策: depth が 3 の時は入力フォーム自体も絶対に表示されないようにガード -->
+    <!-- 安全対策: depth が 3 以上 (4階層目以降) の時は入力フォーム自体も絶対に表示されないようにガード -->
     <div v-if="showReplyForm && depth < 3" class="ms-8">
       <ReplyForm
         :article-id="articleId"

--- a/app/src/features/replies/ReplyThread.vue
+++ b/app/src/features/replies/ReplyThread.vue
@@ -79,12 +79,12 @@ const handleBestUpdated = (replyId: number, isBest: boolean) => {
 <template>
   <div class="d-flex flex-column ga-3">
     <!-- 
-      ✨ 変更箇所: depth が 2 (3階層目) のときは、
+      ✨ 変更箇所: depth が 3 (4階層目) のときは、
       ログイン状態に関わらず can-reply を強制的に false にして返信ボタンを消します。
     -->
     <ReplyItem
       :reply="reply"
-      :can-reply="isAuthenticated && depth < 2"
+      :can-reply="isAuthenticated && depth < 3"
       :replying="showReplyForm"
       :current-user-id="currentUserId"
       :question-author-by-reply-id="questionAuthorByReplyId"
@@ -92,8 +92,8 @@ const handleBestUpdated = (replyId: number, isBest: boolean) => {
       @best-updated="handleBestUpdated"
     />
 
-    <!-- 安全対策: depth が 2 の時は入力フォーム自体も絶対に表示されないようにガード -->
-    <div v-if="showReplyForm && depth < 2" class="ms-8">
+    <!-- 安全対策: depth が 3 の時は入力フォーム自体も絶対に表示されないようにガード -->
+    <div v-if="showReplyForm && depth < 3" class="ms-8">
       <ReplyForm
         :article-id="articleId"
         :parent-id="reply.id"


### PR DESCRIPTION
## やったこと
- 
   1. バックエンド (api/internal/reply/repository/create_reply.go)
       * maxReplyDepth 定数を 2 から 3
         に変更しました。これにより、データベース側でのネスト制限が 4
         階層まで許可されるようになります。
   2. フロントエンド (app/src/features/replies/ReplyThread.vue)
       * 返信ボタンの表示判定およびフォームのガード条件を depth < 2 から depth < 3
         に変更しました。
       * これに合わせ、コード内のコメント（「3 階層目」→「4 階層目」など）も更新しました
- 

## 動作確認
<img width="1459" height="781" alt="image" src="https://github.com/user-attachments/assets/c77e1e6d-2b45-4149-9c8f-bb5f2a4529c7" />
ログアウト時も確認済み

Closes #287