### PR TITLE
余白の変更

### DIFF
--- a/app/src/features/articles/ArticleDetailView.vue
+++ b/app/src/features/articles/ArticleDetailView.vue
@@ -107,7 +107,7 @@ watch(
 
 <template>
   <v-sheet color="grey-lighten-4" min-height="100%">
-    <v-container class="py-8">
+    <v-container class="py-6">
       <v-row justify="center">
         <v-col cols="12" sm="10">
           <div v-if="loading" class="d-flex justify-center py-12">
@@ -166,14 +166,14 @@ watch(
               {{ likeError }}
             </v-alert>
 
-            <v-card flat rounded="lg" class="pa-8">
+            <v-card flat rounded="lg" class="pa-6">
               <MarkdownContent
                 class="text-body-1"
                 :source="article.content ?? ''"
               />
             </v-card>
 
-            <div class="d-flex align-center ga-3 my-6">
+            <div class="d-flex align-center ga-3 my-4">
               <v-btn
                 variant="text"
                 :color="isLiked ? 'red' : undefined"
@@ -183,14 +183,14 @@ watch(
               >
                 <v-icon
                   :icon="isLiked ? 'mdi-heart' : 'mdi-heart-outline'"
-                  size="large"
+                  size="x-large"
                   start
                 />
                 {{ article.likes_count ?? 0 }}
               </v-btn>
             </div>
 
-            <div class="mt-10">
+            <div class="mt-2">
               <ReplySection :article-id="article.id" />
             </div>
           </template>

--- a/app/src/features/articles/ArticlesView.vue
+++ b/app/src/features/articles/ArticlesView.vue
@@ -100,7 +100,7 @@ watch(selectedTags, () => void fetchArticles(), { immediate: true })
   <v-container class="py-8">
     <v-row justify="center">
       <v-col cols="12" sm="10">
-        <div class="d-flex align-center mb-4">
+        <div class="d-flex align-center mb-2">
           <h1 class="text-h4 font-weight-bold">記事一覧</h1>
           <v-spacer />
           <v-btn

--- a/app/src/features/auth/LoginView.vue
+++ b/app/src/features/auth/LoginView.vue
@@ -45,11 +45,13 @@ const onSubmit = async () => {
 </script>
 
 <template>
-  <v-container class="py-8">
+  <v-container class="py-10">
     <v-row justify="center" align="center">
       <v-col cols="12" sm="8" md="6" lg="4">
         <v-card class="pa-6">
-          <v-card-title class="text-h6 text-center">ログイン</v-card-title>
+          <v-card-title class="text-h5 font-weight-bold text-center mb-4">
+            ログイン
+          </v-card-title>
 
           <v-card-text>
             <v-alert
@@ -64,25 +66,28 @@ const onSubmit = async () => {
 
             <v-form @submit.prevent="onSubmit">
               <v-text-field
+                density="comfortable"
                 v-model="name"
                 label="ユーザー名"
                 variant="outlined"
                 required
-                class="mb-4"
+                class="mb-2"
                 :disabled="submitting"
               />
 
               <v-text-field
+                density="comfortable"
                 v-model="password"
                 label="パスワード"
                 type="password"
                 variant="outlined"
                 required
-                class="mb-4"
+                class="mb-2"
                 :disabled="submitting"
               />
 
               <v-btn
+                class="mt-2"
                 type="submit"
                 color="primary"
                 block

--- a/app/src/features/replies/ReplySection.vue
+++ b/app/src/features/replies/ReplySection.vue
@@ -207,7 +207,7 @@ watch(
 </script>
 
 <template>
-  <section class="d-flex flex-column ga-6">
+  <section class="d-flex flex-column ga-2">
     <h2 class="text-h6 font-weight-bold">
       リプライ
       <span v-if="!loading" class="text-medium-emphasis text-body-2 ml-1">

--- a/app/src/features/settings/PasswordChangeView.vue
+++ b/app/src/features/settings/PasswordChangeView.vue
@@ -68,13 +68,13 @@ const onSubmit = async () => {
 </script>
 
 <template>
-  <v-container class="py-8">
+  <v-container class="py-10">
     <v-row justify="center" align="center">
       <v-col cols="12" sm="8" md="6" lg="4">
         <v-card class="pa-6">
-          <v-card-title class="text-h6 text-center"
-            >パスワード変更</v-card-title
-          >
+          <v-card-title class="text-h5 font-weight-bold text-center mb-4">
+            パスワード変更
+          </v-card-title>
 
           <v-card-text>
             <v-alert
@@ -99,29 +99,32 @@ const onSubmit = async () => {
 
             <v-form @submit.prevent="onSubmit">
               <v-text-field
+                density="comfortable"
                 v-model="currentPassword"
                 label="現在のパスワード"
                 type="password"
                 variant="outlined"
                 required
-                class="mb-4"
+                class="mb-2"
                 :disabled="submitting"
                 autocomplete="current-password"
               />
 
               <v-text-field
+                density="comfortable"
                 v-model="newPassword"
                 label="新しいパスワード"
                 type="password"
                 variant="outlined"
                 required
-                class="mb-4"
+                class="mb-2"
                 :disabled="submitting"
                 :rules="newPasswordRules"
                 autocomplete="new-password"
               />
 
               <v-btn
+                class="mt-2"
                 type="submit"
                 color="primary"
                 block


### PR DESCRIPTION
## やったこと
1. 記事詳細画面 (ArticleDetailView.vue)
- 全体的なパディングやマージンを縮小し、コンテンツの密度を上げました。
- いいねボタンのアイコンサイズを large から x-large に大きくしました。
- リプライセクションへのマージンを大幅に削減（mt-10 → mt-2）しました。

2. 記事一覧画面 (ArticlesView.vue)
- ヘッダー部分の下部マージンを微調整（mb-4 → mb-2）しました。

3. ログイン画面 (LoginView.vue)
- タイトルのフォントを大きく太字にし（text-h5 font-weight-bold）、余白を追加しました。
- 入力フィールドの密度を comfortable に設定し、上下の間隔を詰めました。
- ログインボタンの上部にマージンを追加しました。

4. リプライセクション (ReplySection.vue)
- リプライ間のギャップを縮小（ga-6 → ga-2）し、一覧性を高めました。

5. パスワード変更画面 (PasswordChangeView.vue)
- ログイン画面と同様に、タイトルの強調、入力フィールドの密度調整（comfortable）、およびボタン周りの余白調整を行いました。

## 動作確認
<img width="1919" height="1128" alt="スクリーンショット 2026-05-28 115024" src="https://github.com/user-attachments/assets/e4316c5a-2670-4550-92e5-518ab25008cb" />
<img width="1919" height="1199" alt="スクリーンショット 2026-05-28 115032" src="https://github.com/user-attachments/assets/ec46d233-f37d-40ec-8b90-ea5d8d3ec97f" />
<img width="1919" height="1199" alt="スクリーンショット 2026-05-28 115046" src="https://github.com/user-attachments/assets/a7e574ba-ed6a-4c98-95b9-c76e5684266c" />
<img width="1919" height="1199" alt="スクリーンショット 2026-05-28 115055" src="https://github.com/user-attachments/assets/1ea0e41d-312f-487b-8abe-b96079cee0df" />
<img width="1919" height="1199" alt="スクリーンショット 2026-05-28 115101" src="https://github.com/user-attachments/assets/856d591b-2207-499d-afb4-7ccad08073aa" />

close #281