### PR TITLE
ベストアンサー回数UI

### DIFF
--- a/app/src/features/profile/ProfileView.vue
+++ b/app/src/features/profile/ProfileView.vue
@@ -44,12 +44,13 @@ const maxLength = 200
 
 // 記事一覧の絞り込みと同じ思想で、開いているタブを URL に持たせる。
 // リロード・共有でタブ状態を再現できるようにするため。
-const activeTab = computed<'articles' | 'likes' | 'best-answers'>({
+const VALID_TABS = ['articles', 'likes', 'best-answers'] as const
+type TabType = (typeof VALID_TABS)[number]
+
+const activeTab = computed<TabType>({
   get() {
-    const tab = route.query.tab
-    if (tab === 'likes') return 'likes'
-    if (tab === 'best-answers') return 'best-answers'
-    return 'articles'
+    const tab = route.query.tab as string
+    return VALID_TABS.includes(tab as TabType) ? (tab as TabType) : 'articles'
   },
   set(next) {
     void router.replace({
@@ -215,7 +216,7 @@ const goToTag = (tagName: string) => {
                   </h1>
 
                   <v-chip
-                    v-if="profile.best_answer_count"
+                    v-if="(profile.best_answer_count ?? 0) > 0"
                     color="amber-darken-2"
                     size="small"
                     variant="flat"

--- a/app/src/features/profile/ProfileView.vue
+++ b/app/src/features/profile/ProfileView.vue
@@ -32,6 +32,7 @@ const error = ref<string | null>(null)
 
 const postedArticles = ref<ServerArticleJSONResponse[]>([])
 const likedArticles = ref<ServerArticleJSONResponse[]>([])
+const bestAnswerArticles = ref<ServerArticleJSONResponse[]>([])
 const listsLoading = ref(false)
 const listsError = ref<string | null>(null)
 
@@ -43,13 +44,16 @@ const maxLength = 200
 
 // 記事一覧の絞り込みと同じ思想で、開いているタブを URL に持たせる。
 // リロード・共有でタブ状態を再現できるようにするため。
-const activeTab = computed<'articles' | 'likes'>({
+const activeTab = computed<'articles' | 'likes' | 'best-answers'>({
   get() {
-    return route.query.tab === 'likes' ? 'likes' : 'articles'
+    const tab = route.query.tab
+    if (tab === 'likes') return 'likes'
+    if (tab === 'best-answers') return 'best-answers'
+    return 'articles'
   },
   set(next) {
     void router.replace({
-      query: { ...route.query, tab: next === 'likes' ? 'likes' : undefined },
+      query: { ...route.query, tab: next === 'articles' ? undefined : next },
     })
   },
 })
@@ -64,12 +68,14 @@ const fetchLists = async (targetId: number) => {
   listsLoading.value = true
   listsError.value = null
   try {
-    const [posted, liked] = await Promise.all([
+    const [posted, liked, bestAnswers] = await Promise.all([
       api.api.profileArticlesList(targetId),
       api.api.profileLikedArticlesList(targetId),
+      api.api.profileBestAnswerArticlesList(targetId),
     ])
     postedArticles.value = posted.data.articles ?? []
     likedArticles.value = liked.data.articles ?? []
+    bestAnswerArticles.value = bestAnswers.data.articles ?? []
   } catch {
     listsError.value = '記事一覧の取得に失敗しました'
   } finally {
@@ -85,6 +91,7 @@ const fetchProfile = async () => {
   profile.value = null
   postedArticles.value = []
   likedArticles.value = []
+  bestAnswerArticles.value = []
   listsError.value = null
   isEditing.value = false
   try {
@@ -203,9 +210,20 @@ const goToTag = (tagName: string) => {
                 </div>
 
                 <div class="flex-grow-1">
-                  <h1 class="text-h5 font-weight-bold mb-2">
-                    {{ profile.name }}
-                  </h1>
+                  <div class="d-flex align-center ga-2 mb-2">
+                    <h1 class="text-h5 font-weight-bold">
+                      {{ profile.name }}
+                    </h1>
+                    <v-chip
+                      v-if="profile.best_answer_count"
+                      color="amber-darken-2"
+                      size="small"
+                      prepend-icon="mdi-trophy"
+                      class="font-weight-bold"
+                    >
+                      ベストアンサー {{ profile.best_answer_count }}
+                    </v-chip>
+                  </div>
 
                   <p v-if="!isEditing" class="text-body-2 text-medium-emphasis">
                     {{ profile.bio || '自己紹介はまだありません' }}
@@ -263,6 +281,7 @@ const goToTag = (tagName: string) => {
             <v-tabs v-model="activeTab" color="primary" class="mb-4">
               <v-tab value="articles">投稿した記事</v-tab>
               <v-tab value="likes">いいねした記事</v-tab>
+              <v-tab value="best-answers">ベストアンサー獲得記事</v-tab>
             </v-tabs>
 
             <div v-if="listsLoading" class="d-flex justify-center py-12">
@@ -308,6 +327,25 @@ const goToTag = (tagName: string) => {
                     variant="tonal"
                   >
                     まだいいねした記事がありません
+                  </v-alert>
+                </div>
+              </v-window-item>
+
+              <v-window-item value="best-answers">
+                <div class="d-flex flex-column ga-4">
+                  <ArticleCard
+                    v-for="article in bestAnswerArticles"
+                    :key="article.id"
+                    :article="article"
+                    :selected-tags="[]"
+                    @select-tag="goToTag"
+                  />
+                  <v-alert
+                    v-if="bestAnswerArticles.length === 0"
+                    type="info"
+                    variant="tonal"
+                  >
+                    まだベストアンサーを獲得した記事がありません
                   </v-alert>
                 </div>
               </v-window-item>

--- a/app/src/features/profile/ProfileView.vue
+++ b/app/src/features/profile/ProfileView.vue
@@ -210,20 +210,20 @@ const goToTag = (tagName: string) => {
                 </div>
 
                 <div class="flex-grow-1">
-                  <div class="d-flex align-center ga-2 mb-2">
-                    <h1 class="text-h5 font-weight-bold">
-                      {{ profile.name }}
-                    </h1>
-                    <v-chip
-                      v-if="profile.best_answer_count"
-                      color="amber-darken-2"
-                      size="small"
-                      prepend-icon="mdi-trophy"
-                      class="font-weight-bold"
-                    >
-                      ベストアンサー {{ profile.best_answer_count }}
-                    </v-chip>
-                  </div>
+                  <h1 class="text-h5 font-weight-bold mb-2">
+                    {{ profile.name }}
+                  </h1>
+
+                  <v-chip
+                    v-if="profile.best_answer_count"
+                    color="amber-darken-2"
+                    size="small"
+                    variant="flat"
+                    class="mb-2"
+                  >
+                    <v-icon start size="small">mdi-trophy</v-icon>
+                    ベストアンサー {{ profile.best_answer_count }}回
+                  </v-chip>
 
                   <p v-if="!isEditing" class="text-body-2 text-medium-emphasis">
                     {{ profile.bio || '自己紹介はまだありません' }}


### PR DESCRIPTION
## やったこと
1. ベストアンサー獲得回数の表示
- ユーザー名の下に v-chip で獲得回数を表示
- 0回の場合は非表示
- トロフィーアイコン付き）
2. ベストアンサー記事タブの追加
- bestAnswerArticles ref を追加
- activeTab 型を 'best-answers' に拡張
- 3つ目のタブ「ベストアンサー獲得記事」を追加
- 3つ目のウィンドウアイテム（記事一覧）を追加

## 動作確認
<img width="1269" height="969" alt="image" src="https://github.com/user-attachments/assets/752af534-cb42-48bf-8a14-3bbad0e4412e" />


Closes #282